### PR TITLE
Harden web API auth, fix healthcheck and SIGTERM shutdown

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,11 +60,19 @@ GITHUB_BRANCH=main
 
 # --- Web Dashboard --------------------------------------------
 
-# Host and port for the web dashboard
-# Default host: 0.0.0.0 (all interfaces)
-# Default port: random (8000-9000) - set explicitly to keep it stable
-FASTAPI_HOST=0.0.0.0
+# Host and port for the web dashboard.
+# Default host: 127.0.0.1 (localhost only - recommended).
+# The dashboard can read/write this .env file and stop/restart the process,
+# so only expose it (FASTAPI_HOST=0.0.0.0) when you also set WEB_USERNAME and
+# WEB_PASSWORD below.
+# Default port: random (8000-9000) - set explicitly to keep it stable.
+FASTAPI_HOST=127.0.0.1
 FASTAPI_PORT=8080
+
+# Optional HTTP Basic auth for the dashboard/API. Both must be set to enable it.
+# Strongly recommended whenever FASTAPI_HOST is not 127.0.0.1.
+WEB_USERNAME=
+WEB_PASSWORD=
 
 # Default UI theme for new visitors
 # Per-browser preference overrides this and is saved in the browser's localStorage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Unreleased
+
+### Security
+- **Optional dashboard authentication** - HTTP Basic auth gated by `WEB_USERNAME` / `WEB_PASSWORD`. When set, all routes except `/api/health` and `/static` require credentials; when unset, behavior is unchanged. Recommended whenever the dashboard is exposed beyond localhost.
+- **Localhost by default** - `FASTAPI_HOST` now defaults to `127.0.0.1` instead of `0.0.0.0`, so the dashboard (which can read/write `.env` and stop/restart the process) is not exposed on all interfaces by accident. A startup warning is logged when bound to a non-loopback host without credentials.
+
+### Bug Fixes
+- **Docker healthcheck** - Replaced the `requests`-based healthcheck (an undeclared dependency that left the container permanently `unhealthy`) with a stdlib `urllib` check that exits non-zero on failure.
+- **Graceful shutdown** - Signal handlers were registered at import time on an event loop that `asyncio.run()` never used, so `SIGTERM` (e.g. `docker stop`) skipped cleanup. They are now attached to the running loop in `async_main()`.
+
+### Improvements
+- **Docker Compose** - Mount `.env` read-write so the in-app config editor and add/remove ID/URL features persist (the previous `:ro` mount silently broke them), removed the obsolete `version:` key, and documented the new auth variables.
+- **Cleanup** - Removed duplicate `_http_session`, `_session_lock`, and `_circuit_breaker_timeout` global declarations.
+
+---
+
 ## v1.0.5e - October 3, 2025
 
 ### New Features

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,9 @@ EXPOSE 8080
 ENV FASTAPI_HOST=0.0.0.0 \
     FASTAPI_PORT=8080
 
-# Health check
+# Health check (uses stdlib urllib so no extra dependency is required)
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD python -c "import requests; requests.get('http://localhost:8080/api/health')"
+    CMD python -c "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8080/api/health', timeout=5).status == 200 else 1)"
 
 # Run the application
 CMD ["python", "main.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   testflight-notifier:
     build: .
@@ -14,13 +12,18 @@ services:
       - FASTAPI_HOST=0.0.0.0
       - FASTAPI_PORT=8080
       - TZ=America/New_York  # Set your timezone
+      # The dashboard is exposed on 0.0.0.0 here, so protect it with auth.
+      # Set these (e.g. in .env) to require an HTTP Basic login:
+      # - WEB_USERNAME=admin
+      # - WEB_PASSWORD=change-me
     volumes:
-      # Optional: Mount .env file from host
-      - ./.env:/app/.env:ro
+      # Mount .env read-write so the in-app config editor and add/remove
+      # ID/URL features can persist changes back to the host file.
+      - ./.env:/app/.env
       # Optional: Persistent data directory
       - ./data:/app/data
     healthcheck:
-      test: ["CMD", "python", "-c", "import requests; requests.get('http://localhost:8080/api/health')"]
+      test: ["CMD", "python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8080/api/health', timeout=5).status == 200 else 1)"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/main.py
+++ b/main.py
@@ -9,11 +9,13 @@ import logging
 import signal
 import random
 import itertools
+import secrets
 import time
 from collections import deque
 from contextlib import asynccontextmanager
-from fastapi import FastAPI, HTTPException, Form, Request
+from fastapi import FastAPI, HTTPException, Form, Request, Depends
 from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from bs4 import BeautifulSoup
@@ -64,6 +66,13 @@ ENABLE_UPDATE_CHECKER = os.getenv("ENABLE_UPDATE_CHECKER", "true").lower() in (
 # UI default theme: "dark" or "light" (users can override per-browser via the toggle)
 _raw_theme = os.getenv("UI_THEME", "dark").lower().strip()
 UI_THEME = "dark" if _raw_theme not in ("light", "dark") else _raw_theme
+
+# Optional HTTP Basic auth for the web dashboard/API. Enabled only when BOTH
+# WEB_USERNAME and WEB_PASSWORD are set. When unset, the app relies on binding
+# to localhost (the default host) for protection. Set these whenever the
+# dashboard is exposed beyond localhost (e.g. in Docker or behind a proxy).
+WEB_USERNAME = os.getenv("WEB_USERNAME", "").strip()
+WEB_PASSWORD = os.getenv("WEB_PASSWORD", "").strip()
 
 # Status tracking for change notifications
 _previous_status = {}  # tf_id -> TestFlightStatus
@@ -165,12 +174,6 @@ class MetricsCollector:
 
 # Global metrics collector
 _metrics = MetricsCollector()
-
-_circuit_breaker_timeout = 300  # 5 minutes
-
-# Global HTTP session and lock
-_http_session = None
-_session_lock = threading.Lock()
 
 
 def is_circuit_breaker_open(url: str) -> bool:
@@ -1325,13 +1328,16 @@ def handle_shutdown_signal():
     shutdown_event.set()
 
 
-# Only attach signal handlers on non-Windows
-if os.name != "nt":
-    try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
+def install_signal_handlers():
+    """Attach SIGINT/SIGTERM handlers to the running event loop.
+
+    Must be called from within the running loop (e.g. async_main) so the
+    handlers are registered on the loop that actually serves the app.
+    Falls back gracefully on platforms (Windows) that don't support it.
+    """
+    if os.name == "nt":
+        return
+    loop = asyncio.get_running_loop()
     for sig in (signal.SIGINT, signal.SIGTERM):
         try:
             loop.add_signal_handler(sig, handle_shutdown_signal)
@@ -1380,8 +1386,41 @@ async def lifespan(app: FastAPI):
         await cleanup_http_session()
 
 
+# Optional HTTP Basic auth (see WEB_USERNAME / WEB_PASSWORD above).
+_basic_security = HTTPBasic(auto_error=False)
+
+# Paths that must stay reachable without credentials: the health check (used by
+# Docker/orchestrators) and static assets (served by a sub-app anyway).
+_AUTH_EXEMPT_PREFIXES = ("/api/health", "/static")
+
+
+def require_auth(
+    request: Request,
+    credentials: Optional[HTTPBasicCredentials] = Depends(_basic_security),
+):
+    """Enforce HTTP Basic auth when credentials are configured.
+
+    No-op when WEB_USERNAME/WEB_PASSWORD are unset (localhost-only deployments).
+    """
+    if not (WEB_USERNAME and WEB_PASSWORD):
+        return
+    if request.url.path.startswith(_AUTH_EXEMPT_PREFIXES):
+        return
+    valid = (
+        credentials is not None
+        and secrets.compare_digest(credentials.username, WEB_USERNAME)
+        and secrets.compare_digest(credentials.password, WEB_PASSWORD)
+    )
+    if not valid:
+        raise HTTPException(
+            status_code=401,
+            detail="Invalid or missing credentials",
+            headers={"WWW-Authenticate": "Basic"},
+        )
+
+
 # FastAPI server
-app = FastAPI(lifespan=lifespan)
+app = FastAPI(lifespan=lifespan, dependencies=[Depends(require_auth)])
 app.mount("/static", StaticFiles(directory="static"), name="static")
 templates = Jinja2Templates(directory="templates")
 
@@ -2069,8 +2108,22 @@ async def start_fastapi():
     """Start FastAPI server as an async task with graceful shutdown handling."""
     server = None
     try:
-        default_host = os.getenv("FASTAPI_HOST", "0.0.0.0")
+        # Default to loopback so the dashboard (which can read/write .env and
+        # control the process) is not exposed on all interfaces by accident.
+        # Set FASTAPI_HOST=0.0.0.0 to expose it, ideally with WEB_USERNAME/
+        # WEB_PASSWORD configured.
+        default_host = os.getenv("FASTAPI_HOST", "127.0.0.1")
         default_port = int(os.getenv("FASTAPI_PORT", random.randint(8000, 9000)))
+
+        if default_host not in ("127.0.0.1", "localhost", "::1") and not (
+            WEB_USERNAME and WEB_PASSWORD
+        ):
+            logging.warning(
+                "Web dashboard is bound to %s without WEB_USERNAME/WEB_PASSWORD "
+                "set. Anyone who can reach this port can read your .env secrets "
+                "and control the process. Set credentials to enable auth.",
+                default_host,
+            )
 
         logging.info(f"Starting FastAPI server on {default_host}:{default_port}")
 
@@ -2126,6 +2179,10 @@ async def async_main():
     try:
         logging.info("Starting TestFlight Apprise Notifier v%s", __version__)
         logging.info("All services starting...")
+
+        # Register signal handlers on the running loop so SIGTERM (e.g.
+        # `docker stop`) triggers a graceful shutdown.
+        install_signal_handlers()
 
         # Create tasks
         watching_task = asyncio.create_task(start_watching())


### PR DESCRIPTION
Hardening pass on the 2.0 `pre-release` dashboard. Each change is independent.

## 🔒 Web API authentication (the main one)
The dashboard/API had **no auth** while defaulting to `0.0.0.0`, so anyone who could reach the port could read `.env` verbatim (`GET /api/config` — includes every Apprise token/password), overwrite it (`POST /api/config`), and stop/restart the process.

- Added **optional HTTP Basic auth** via `WEB_USERNAME` / `WEB_PASSWORD`. Enabled only when both are set; otherwise a no-op (relies on localhost binding). Browser-native prompt, so the dashboard's `fetch()` calls inherit credentials with no frontend changes.
- `/api/health` and `/static` stay exempt (healthcheck + assets).
- **Default `FASTAPI_HOST` → `127.0.0.1`** (was `0.0.0.0`). Startup now logs a warning if bound to a non-loopback host without credentials.

## 🩺 Docker healthcheck
The healthcheck ran `python -c "import requests; ..."`, but `requests` isn't a dependency — the container was **always `unhealthy`**. Switched to stdlib `urllib`, and it now exits non-zero on a bad status.

## 🛑 Graceful shutdown (SIGTERM)
Signal handlers were registered at import time on an `asyncio.new_event_loop()` that `asyncio.run()` never uses, so `docker stop` (SIGTERM) never triggered cleanup. Moved registration into `async_main()` on the actually-running loop.

## 🧹 Cleanup
- Removed duplicate `_http_session` / `_session_lock` / `_circuit_breaker_timeout` global declarations.
- `docker-compose.yml`: mount `.env` **read-write** (the in-app config editor + add/remove ID/URL write to it; the old `:ro` mount silently broke those in Docker), dropped the obsolete `version:` key, documented the auth vars.
- `.env.example`: documented `WEB_USERNAME` / `WEB_PASSWORD` and the new host default.

## Testing
- `py_compile` + existing suite: **15 passed**.
- TestClient checks: no creds → endpoints open (backward compatible); creds set → `/api/config`, `/`, control endpoints return **401** without/with-wrong creds and **200** with correct creds; `/api/health` reachable without creds in both modes.

## Not included (follow-ups worth their own PRs)
- `restart` via `subprocess.Popen` doesn't work in Docker and lands on a new random port — consider removing or documenting.
- Dockerfile still runs as **root** (skipped to avoid `.env`/`data` write-permission regressions).
- Dead code: unused circuit-breaker (`record_request_*` never called) and unused `check_testflight_status_with_retry` / `check_multiple_testflight_urls`.
- Blocking `send_notification` called from async paths (heartbeat, add/remove handlers) — use the async variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)