### PR TITLE
Fix Docker restart, run as non-root, async notifications, dead-code cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,13 @@
 ### Bug Fixes
 - **Docker healthcheck** - Replaced the `requests`-based healthcheck (an undeclared dependency that left the container permanently `unhealthy`) with a stdlib `urllib` check that exits non-zero on failure.
 - **Graceful shutdown** - Signal handlers were registered at import time on an event loop that `asyncio.run()` never used, so `SIGTERM` (e.g. `docker stop`) skipped cleanup. They are now attached to the running loop in `async_main()`.
+- **Restart from the dashboard** - Now re-executes in place via `os.execv` instead of spawning a child process. The previous approach spawned a child that died with the container (so restart did nothing under Docker). Also warns when `FASTAPI_PORT` is unset, since the dashboard could otherwise return on a different random port.
 
 ### Improvements
 - **Docker Compose** - Mount `.env` read-write so the in-app config editor and add/remove ID/URL features persist (the previous `:ro` mount silently broke them), removed the obsolete `version:` key, and documented the new auth variables.
-- **Cleanup** - Removed duplicate `_http_session`, `_session_lock`, and `_circuit_breaker_timeout` global declarations.
+- **Non-root container** - The Docker image now runs as an unprivileged user (uid 10001) instead of root.
+- **Non-blocking notifications** - The heartbeat loop and the stop/restart endpoints now send notifications via the async helper so a slow notification service no longer stalls the event loop.
+- **Cleanup** - Removed duplicate `_http_session`, `_session_lock`, and `_circuit_breaker_timeout` global declarations, the unused circuit-breaker helpers (`is_circuit_breaker_open` / `record_request_*`, never wired into the request path — the `/api/health` `circuit_breaker` field is gone), and the unused `check_multiple_testflight_urls` utility.
 
 ---
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,12 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy application files
 COPY . .
 
-# Create data directory for persistent storage (optional)
-RUN mkdir -p /app/data
+# Create a non-root user and give it ownership of the app + data directory so
+# the process (and the in-app .env editor) can write where it needs to.
+RUN useradd --create-home --uid 10001 appuser \
+    && mkdir -p /app/data \
+    && chown -R appuser:appuser /app
+USER appuser
 
 # Expose FastAPI port
 EXPOSE 8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,9 @@ services:
       # Set these (e.g. in .env) to require an HTTP Basic login:
       # - WEB_USERNAME=admin
       # - WEB_PASSWORD=change-me
+    # The container runs as a non-root user (uid 10001). For the in-app config
+    # editor to write the mounted .env, ensure the host files are writable by
+    # that uid, e.g. `chown 10001 .env data` (or set `user:` to match yours).
     volumes:
       # Mount .env read-write so the in-app config editor and add/remove
       # ID/URL features can persist changes back to the host file.

--- a/main.py
+++ b/main.py
@@ -46,11 +46,6 @@ load_dotenv()
 # Enable status caching with 5-minute TTL for improved performance
 enable_status_cache(ttl_seconds=300)
 
-# Circuit breaker for external requests
-_request_failures = {}
-_circuit_breaker_threshold = 5
-_circuit_breaker_timeout = 300  # 5 minutes
-
 # Global HTTP session and lock
 _http_session = None
 _session_lock = threading.Lock()
@@ -174,33 +169,6 @@ class MetricsCollector:
 
 # Global metrics collector
 _metrics = MetricsCollector()
-
-
-def is_circuit_breaker_open(url: str) -> bool:
-    """Check if circuit breaker is open for a URL."""
-    if url in _request_failures:
-        failures, last_failure = _request_failures[url]
-        if failures >= _circuit_breaker_threshold:
-            if time.time() - last_failure < _circuit_breaker_timeout:
-                return True
-            else:
-                # Reset circuit breaker after timeout
-                del _request_failures[url]
-    return False
-
-
-def record_request_failure(url: str):
-    """Record a request failure for circuit breaker."""
-    if url not in _request_failures:
-        _request_failures[url] = [0, 0]
-    _request_failures[url][0] += 1
-    _request_failures[url][1] = time.time()
-
-
-def record_request_success(url: str):
-    """Record a request success, resetting circuit breaker."""
-    if url in _request_failures:
-        del _request_failures[url]
 
 
 async def get_http_session() -> aiohttp.ClientSession:
@@ -1447,9 +1415,6 @@ async def home(request: Request):
 async def health_check():
     """Health check endpoint for monitoring."""
     current_ids = get_current_id_list()
-    circuit_breaker_status = {
-        url: failures for url, (failures, _) in _request_failures.items()
-    }
 
     return {
         "status": "healthy",
@@ -1459,16 +1424,6 @@ async def health_check():
         "cache_stats": {
             "app_names": len(app_name_cache.cache),
             "app_icons": len(app_icon_cache.cache),
-        },
-        "circuit_breaker": {
-            "open_circuits": len(
-                [
-                    url
-                    for url in circuit_breaker_status.keys()
-                    if is_circuit_breaker_open(url)
-                ]
-            ),
-            "total_tracked": len(circuit_breaker_status),
         },
         "http_session": (
             "active" if _http_session and not _http_session.closed else "inactive"
@@ -1807,7 +1762,7 @@ async def stop_application():
     # Send notification about the stop
     try:
         msg = "🛑 TestFlight Apprise Notifier stopped via web interface"
-        send_notification(msg, apobj)
+        await send_notification_async(msg, apobj)
     except Exception:
         pass  # Ignore notification errors during shutdown
 
@@ -1816,46 +1771,46 @@ async def stop_application():
     return {"message": "Application is shutting down..."}
 
 
+def _perform_restart():
+    """Replace the current process image with a fresh instance.
+
+    Using os.execv (rather than spawning a child via subprocess) keeps the
+    same PID, so it works both on bare metal and inside a container where the
+    app is PID 1 - a spawned child would die when the original process exits
+    and take the container down with it.
+    """
+    import sys
+
+    python_executable = sys.executable
+    script_path = os.path.abspath(sys.argv[0])
+    logging.info("Re-executing application for restart...")
+    os.execv(python_executable, [python_executable, script_path])
+
+
 @app.post("/api/control/restart")
 async def restart_application():
-    """Restart the application."""
+    """Restart the application by re-executing it in place."""
     logging.info("Restart command received via web interface")
 
     # Send notification about the restart
     try:
         msg = "🔄 TestFlight Apprise Notifier restarting via web interface"
-        send_notification(msg, apobj)
+        await send_notification_async(msg, apobj)
     except Exception:
         pass  # Ignore notification errors during restart
 
-    # Get the current Python executable and script path
-    import sys
-    import subprocess
-    import os
-
-    python_executable = sys.executable
-    script_path = os.path.abspath(sys.argv[0])
-
-    try:
-        # Start a new instance of the application
-        subprocess.Popen(
-            [python_executable, script_path],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            stdin=subprocess.DEVNULL,
-            start_new_session=True,
+    # The re-exec inherits the current environment, so an unset FASTAPI_PORT
+    # means a new random port is chosen on restart and the dashboard URL changes.
+    if not os.getenv("FASTAPI_PORT"):
+        logging.warning(
+            "FASTAPI_PORT is not set; the dashboard may come back on a "
+            "different random port after restart. Set FASTAPI_PORT to keep it stable."
         )
 
-        logging.info("New application instance started, shutting down current instance")
-
-        # Trigger graceful shutdown of current instance
-        handle_shutdown_signal()
-
-        return {"message": "Application is restarting..."}
-
-    except Exception as e:
-        logging.error(f"Failed to restart application: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to restart: {str(e)}")
+    # Defer the re-exec briefly so this HTTP response can flush to the client
+    # before the process image is replaced.
+    threading.Timer(1.0, _perform_restart).start()
+    return {"message": "Application is restarting..."}
 
 
 @app.get("/api/config")
@@ -2077,7 +2032,7 @@ async def heartbeat():
         while True:
             current_time = format_datetime(datetime.now())
             message = f"Heartbeat - {current_time}"
-            send_notification(message, apobj)
+            await send_notification_async(message, apobj)
             print_green(message)
             await asyncio.sleep(HEARTBEAT_INTERVAL)
     except asyncio.CancelledError:

--- a/utils/testflight.py
+++ b/utils/testflight.py
@@ -397,45 +397,6 @@ async def check_testflight_status(
         return result
 
 
-async def check_multiple_testflight_urls(
-    session: aiohttp.ClientSession, urls: list[str], timeout: int = 10
-) -> Dict[str, Dict]:
-    """
-    Check multiple TestFlight URLs concurrently.
-
-    Args:
-        session: Active aiohttp ClientSession for connection pooling
-        urls: List of TestFlight URLs to check
-        timeout: Request timeout in seconds (default: 10)
-
-    Returns:
-        Dictionary mapping URLs to their status results
-    """
-    import asyncio
-
-    # Create tasks for all URLs
-    tasks = [check_testflight_status(session, url, timeout) for url in urls]
-
-    # Execute concurrently
-    results = await asyncio.gather(*tasks, return_exceptions=True)
-
-    # Build result dictionary
-    result_dict = {}
-    for i, result in enumerate(results):
-        if isinstance(result, Exception):
-            # Handle exceptions from gather
-            result_dict[urls[i]] = {
-                "url": urls[i],
-                "status": TestFlightStatus.ERROR,
-                "status_text": "Error",
-                "error": str(result),
-            }
-        else:
-            result_dict[result["url"]] = result
-
-    return result_dict
-
-
 async def check_testflight_status_with_retry(
     session: aiohttp.ClientSession,
     url: str,


### PR DESCRIPTION
Follow-up items noted at the bottom of #19 (now merged).

## 🔄 Restart actually works in Docker now
`POST /api/control/restart` spawned a child via `subprocess.Popen`; the child died when the original process exited, so under Docker (app = PID 1) the container just went down and restart did nothing. Now it **re-execs in place with `os.execv`**, which preserves the PID and works both on bare metal and in containers. The re-exec is deferred ~1s via a timer so the HTTP response flushes first, and it **warns when `FASTAPI_PORT` is unset** (otherwise the restarted app may bind a different random port).

## 🔒 Non-root container
The image ran as **root**. It now creates an unprivileged user (uid 10001) and `chown`s `/app` so the app and the in-app `.env` editor can still write. `docker-compose.yml` documents the uid (host-mounted `.env`/`data` must be writable by it).

## ⚡ Non-blocking notifications
The **heartbeat loop** and the **stop/restart** endpoints called the synchronous `send_notification`, blocking the event loop on every notify. They now use `send_notification_async`. (The one-shot add/remove ID/URL helpers are sync functions and left as-is — lower impact; a deeper refactor can follow.)

## 🧹 Dead-code cleanup
- Removed the **circuit breaker** (`is_circuit_breaker_open`, `record_request_failure/success`, `_request_failures` + threshold/timeout globals). It was never wired into the request path, so it never tripped; the `/api/health` `circuit_breaker` field (always zero) is removed with it.
- Removed the unused `check_multiple_testflight_urls` utility. **Kept** `check_testflight_status_with_retry` — it's exercised by the test suite.

## Testing
- Existing suite: **15 passed**.
- TestClient: `/api/health` returns 200 without the `circuit_breaker` key; restart helper present; app imports cleanly.

### Note on the `/api/health` change
Dropping the `circuit_breaker` field is a small response-shape change. Since it only ever reported zeros, I judged removal cleaner than wiring the breaker in — happy to instead make the breaker functional if you'd prefer to keep the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)