### PR TITLE
Mobile/PWA polish: manifest, theme-color, reduced-motion

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1165,3 +1165,16 @@ select.input {
   margin-top: 14px;
   flex-wrap: wrap;
 }
+
+/* ── Reduced motion ─────────────────────────────────────────── */
+/* Honor the OS "reduce motion" setting: drop transitions/animations. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/static/icon.svg
+++ b/static/icon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="TestFlight Apprise Notifier">
+  <!-- Full-bleed background so the icon also works as a maskable PWA icon -->
+  <rect width="512" height="512" fill="#6366f1"/>
+  <!-- Paper-plane glyph, centered within the maskable safe zone -->
+  <g fill="#ffffff">
+    <path d="M376 150 152 270c-8 4-7 16 1 19l60 22 24 74c3 8 14 9 19 2l34-46 70 51c7 5 17 1 19-8l38-225c2-11-9-19-19-13z" opacity="0.96"/>
+    <path d="M236 333l-1 49c0 9 11 13 17 6l27-33z" fill="#c7d2fe"/>
+  </g>
+</svg>

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -15,6 +15,9 @@ function initTheme() {
 function setTheme(theme) {
   document.documentElement.setAttribute('data-theme', theme);
   localStorage.setItem('tf-theme', theme);
+  // Keep the mobile browser chrome (status/address bar) matching the theme.
+  const meta = document.getElementById('theme-color-meta');
+  if (meta) meta.setAttribute('content', theme === 'dark' ? '#0d1117' : '#f3f4f6');
   const moon = document.getElementById('theme-icon-moon');
   const sun  = document.getElementById('theme-icon-sun');
   if (theme === 'dark') {

--- a/static/manifest.webmanifest
+++ b/static/manifest.webmanifest
@@ -1,0 +1,19 @@
+{
+  "name": "TestFlight Apprise Notifier",
+  "short_name": "TF Notifier",
+  "description": "Monitor TestFlight beta availability and send Apprise notifications.",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "orientation": "any",
+  "background_color": "#0d1117",
+  "theme_color": "#0d1117",
+  "icons": [
+    {
+      "src": "/static/icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,8 +2,21 @@
 <html lang="en" data-theme="{{ ui_theme }}">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <meta name="description" content="Dashboard for monitoring TestFlight beta availability and sending Apprise notifications.">
   <title>TestFlight Apprise Notifier</title>
+
+  <!-- Mobile / PWA -->
+  <meta name="theme-color" id="theme-color-meta" content="{% if ui_theme == 'light' %}#f3f4f6{% else %}#0d1117{% endif %}">
+  <meta name="color-scheme" content="dark light">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <meta name="apple-mobile-web-app-title" content="TF Notifier">
+  <link rel="icon" type="image/svg+xml" href="/static/icon.svg">
+  <link rel="apple-touch-icon" href="/static/icon.svg">
+  <link rel="manifest" href="/static/manifest.webmanifest">
+
   <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>


### PR DESCRIPTION
**PR A of 3** from the enhancement review. Frontend-only — independent of #20.

The dashboard was already genuinely responsive (bottom tab bar, safe-area insets, 44px touch targets, section-scoped polling). This closes the remaining mobile gaps.

## Changes
- **Installable (PWA)** — added `static/manifest.webmanifest` (standalone display, app name/colors, maskable SVG icon) and the `<link rel="manifest">`, so the dashboard supports "Add to Home Screen".
- **App icon** — `static/icon.svg` (paper-plane), used as favicon, `apple-touch-icon`, and manifest icon.
- **Browser chrome matches theme** — `<meta name="theme-color">` set from the server default on first paint and kept in sync with the light/dark toggle in `setTheme()`.
- **iOS/Android web-app meta** — `apple-mobile-web-app-capable`, status-bar style, `mobile-web-app-capable`, `apple-mobile-web-app-title`, plus `viewport-fit=cover` for notch safe areas and a `meta description`.
- **Reduced motion** — `@media (prefers-reduced-motion: reduce)` disables transitions/animations for users who ask the OS to limit motion.

## Testing
- TestClient: `/` includes the new tags; `/static/manifest.webmanifest` serves `200 application/manifest+json`; `/static/icon.svg` serves `200 image/svg+xml`.

## Note
Icons are SVG (works as favicon + Chrome/Android maskable + manifest). iOS Safari prefers a PNG `apple-touch-icon`; if you want a pixel-perfect home-screen icon on iOS, a 180×180 PNG is a trivial follow-up — I left it out to avoid committing a binary without your say-so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)