### PR TITLE
Use Pydantic request models for ID/URL endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - **Docker Compose** - Mount `.env` read-write so the in-app config editor and add/remove ID/URL features persist (the previous `:ro` mount silently broke them), removed the obsolete `version:` key, and documented the new auth variables.
 - **Non-root container** - The Docker image now runs as an unprivileged user (uid 10001) instead of root.
 - **Non-blocking notifications** - The heartbeat loop and the stop/restart endpoints now send notifications via the async helper so a slow notification service no longer stalls the event loop.
+- **Typed request models** - The TestFlight ID and Apprise URL endpoints now use Pydantic request models instead of manual JSON parsing, giving proper request validation and accurate schemas in the auto-generated API docs at `/docs`.
 - **Cleanup** - Removed duplicate `_http_session`, `_session_lock`, and `_circuit_breaker_timeout` global declarations, the unused circuit-breaker helpers (`is_circuit_breaker_open` / `record_request_*`, never wired into the request path — the `/api/health` `circuit_breaker` field is gone), and the unused `check_multiple_testflight_urls` utility.
 
 ---

--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
+from pydantic import BaseModel, Field
 from bs4 import BeautifulSoup
 from dotenv import load_dotenv
 from datetime import datetime
@@ -1354,6 +1355,26 @@ async def lifespan(app: FastAPI):
         await cleanup_http_session()
 
 
+# --- Request models ------------------------------------------------------
+class TestFlightIdRequest(BaseModel):
+    """Body for single TestFlight ID validate/add requests."""
+
+    id: str = Field(..., description="TestFlight beta ID")
+
+
+class AppriseUrlRequest(BaseModel):
+    """Body for single Apprise URL validate/add requests."""
+
+    url: str = Field(..., description="Apprise notification URL")
+
+
+class BatchIdRequest(BaseModel):
+    """Body for batch add/remove of TestFlight IDs."""
+
+    add: list[str] = Field(default_factory=list, description="IDs to add")
+    remove: list[str] = Field(default_factory=list, description="IDs to remove")
+
+
 # Optional HTTP Basic auth (see WEB_USERNAME / WEB_PASSWORD above).
 _basic_security = HTTPBasic(auto_error=False)
 
@@ -1526,10 +1547,9 @@ async def get_testflight_ids_details():
 
 
 @app.post("/api/testflight-ids/validate")
-async def validate_id(request: Request):
+async def validate_id(payload: TestFlightIdRequest):
     """Validate a TestFlight ID."""
-    data = await request.json()
-    tf_id = data.get("id", "").strip()
+    tf_id = payload.id.strip()
 
     if not tf_id:
         raise HTTPException(status_code=400, detail="TestFlight ID is required")
@@ -1557,10 +1577,9 @@ async def validate_id(request: Request):
 
 
 @app.post("/api/testflight-ids")
-async def add_id(request: Request):
+async def add_id(payload: TestFlightIdRequest):
     """Add a new TestFlight ID."""
-    data = await request.json()
-    tf_id = data.get("id", "").strip()
+    tf_id = payload.id.strip()
 
     if not tf_id:
         raise HTTPException(status_code=400, detail="TestFlight ID is required")
@@ -1589,7 +1608,7 @@ async def remove_id(tf_id: str):
 
 
 @app.post("/api/testflight-ids/batch")
-async def batch_operations(request: Request):
+async def batch_operations(payload: BatchIdRequest):
     """
     Perform batch operations on TestFlight IDs.
 
@@ -1606,9 +1625,8 @@ async def batch_operations(request: Request):
         "testflight_ids": [...]
     }
     """
-    data = await request.json()
-    ids_to_add = data.get("add", [])
-    ids_to_remove = data.get("remove", [])
+    ids_to_add = payload.add
+    ids_to_remove = payload.remove
 
     result = {
         "added": {"successful": [], "failed": []},
@@ -1707,10 +1725,9 @@ async def get_apprise_urls():
 
 
 @app.post("/api/apprise-urls/validate")
-async def validate_url(request: Request):
+async def validate_url(payload: AppriseUrlRequest):
     """Validate an Apprise URL."""
-    data = await request.json()
-    url = data.get("url", "").strip()
+    url = payload.url.strip()
 
     if not url:
         raise HTTPException(status_code=400, detail="Apprise URL is required")
@@ -1724,10 +1741,9 @@ async def validate_url(request: Request):
 
 
 @app.post("/api/apprise-urls")
-async def add_url(request: Request):
+async def add_url(payload: AppriseUrlRequest):
     """Add a new Apprise URL."""
-    data = await request.json()
-    url = data.get("url", "").strip()
+    url = payload.url.strip()
 
     if not url:
         raise HTTPException(status_code=400, detail="Apprise URL is required")


### PR DESCRIPTION
**PR B of 3** from the enhancement review. **Stacked on #20** (`cleanup/restart-docker-deadcode`) since it touches `main.py` — base auto-retargets to `pre-release` once #20 merges.

## What
The ID/URL endpoints parsed bodies by hand (`await request.json()` then `data.get(...)`). This swaps them to typed **Pydantic models**:

- `TestFlightIdRequest { id }` → `validate_id`, `add_id`
- `AppriseUrlRequest { url }` → `validate_url`, `add_url`
- `BatchIdRequest { add[], remove[] }` → `batch_operations`

## Why
- Real request validation and **accurate schemas in the auto-generated docs at `/docs`** (which are now also behind the auth added in #19).
- Less boilerplate, clearer handler signatures.

Behavior is intentionally preserved: the existing empty-value → `400` checks with **string** `detail` are kept, so the dashboard's `data.detail` error rendering is unchanged. A missing key now returns FastAPI's standard `422` (the frontend always sends the key, so the UI never hits that path).

## Testing
- TestClient: bad-format ID → `200 {valid:false}`; empty → `400` string detail; missing key → `422`; URL validate works; `/openapi.json` now contains `TestFlightIdRequest`; `/docs` → `200`.
- Existing suite: **15 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)