### PR TITLE
Add API-level tests for the dashboard endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 - **Docker Compose** - Mount `.env` read-write so the in-app config editor and add/remove ID/URL features persist (the previous `:ro` mount silently broke them), removed the obsolete `version:` key, and documented the new auth variables.
 - **Cleanup** - Removed duplicate `_http_session`, `_session_lock`, and `_circuit_breaker_timeout` global declarations.
 
+### Tests
+- **API coverage** - Added `tests/test_api.py` (TestClient) covering the health/metrics/list endpoints, log-limit validation, the add/remove ID and URL flows, and the optional HTTP Basic auth.
+
 ---
 
 ## v1.0.5e - October 3, 2025

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -1,3 +1,4 @@
 pytest>=9.0.3
 pytest-asyncio>=1.3.0
 pytest-mock>=3.15.1
+httpx>=0.27,<1.0  # required by FastAPI/Starlette TestClient (tests/test_api.py)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,137 @@
+"""
+API-level tests for the FastAPI dashboard.
+
+These drive the app via Starlette's TestClient and avoid real network calls by
+monkeypatching the TestFlight validation and the .env writer / notifier. They
+cover the read endpoints, input validation, the add/remove flows, and the
+optional HTTP Basic auth.
+"""
+
+import importlib
+import os
+import urllib.parse
+
+import pytest
+from fastapi.testclient import TestClient
+
+# The app reads required config at import time, so set it before importing.
+os.environ.setdefault("APPRISE_URL", "json://localhost/")
+os.environ.setdefault("ENABLE_UPDATE_CHECKER", "false")
+# Default import: auth disabled (the auth test reloads with it enabled).
+os.environ.pop("WEB_USERNAME", None)
+os.environ.pop("WEB_PASSWORD", None)
+
+import main  # noqa: E402
+
+
+@pytest.fixture
+def client():
+    # No context manager -> lifespan startup is skipped, so no background
+    # update task / outbound calls are spawned during tests.
+    return TestClient(main.app)
+
+
+# ── Read endpoints ──────────────────────────────────────────────
+def test_health_is_open_and_well_formed(client):
+    r = client.get("/api/health")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "healthy"
+    assert "version" in body and "uptime_seconds" in body
+
+
+def test_metrics_shape(client):
+    r = client.get("/api/metrics")
+    assert r.status_code == 200
+    assert "total_checks" in r.json()
+
+
+def test_list_ids(client):
+    r = client.get("/api/testflight-ids")
+    assert r.status_code == 200
+    assert "testflight_ids" in r.json()
+
+
+def test_apprise_urls_list(client):
+    r = client.get("/api/apprise-urls")
+    assert r.status_code == 200
+    assert "apprise_urls" in r.json()
+
+
+# ── Input validation ────────────────────────────────────────────
+def test_logs_limit_validation(client):
+    assert client.get("/api/logs?limit=0").status_code == 400
+    assert client.get("/api/logs?limit=100000").status_code == 400
+    r = client.get("/api/logs?limit=5")
+    assert r.status_code == 200 and "logs" in r.json()
+
+
+def test_validate_bad_format_does_not_hit_network(client):
+    # An invalid format is rejected before any HTTP request is made.
+    r = client.post("/api/testflight-ids/validate", json={"id": "!!bad!!"})
+    assert r.status_code == 200
+    assert r.json()["valid"] is False
+
+
+# ── Add / remove flows (network + .env writes stubbed) ──────────
+def test_add_and_remove_testflight_id(client, monkeypatch):
+    async def fake_validate(tf_id):
+        return True, "ok"
+
+    monkeypatch.setattr(main, "validate_testflight_id", fake_validate)
+    monkeypatch.setattr(main, "update_env_file", lambda *a, **k: True)
+    monkeypatch.setattr(main, "send_notification", lambda *a, **k: None)
+
+    test_id = "abcd1234"
+    main.current_id_list[:] = [x for x in main.current_id_list if x != test_id]
+
+    r = client.post("/api/testflight-ids", json={"id": test_id})
+    assert r.status_code == 200, r.text
+    assert test_id in r.json()["testflight_ids"]
+
+    r = client.delete(f"/api/testflight-ids/{test_id}")
+    assert r.status_code == 200
+    assert test_id not in r.json()["testflight_ids"]
+
+
+def test_remove_unknown_id_404(client):
+    r = client.delete("/api/testflight-ids/does-not-exist")
+    assert r.status_code == 404
+
+
+def test_add_and_remove_apprise_url(client, monkeypatch):
+    monkeypatch.setattr(main, "update_env_file", lambda *a, **k: True)
+    monkeypatch.setattr(main, "send_notification", lambda *a, **k: None)
+
+    url = "discord://aaaa/bbbb"
+    main.current_apprise_urls[:] = [u for u in main.current_apprise_urls if u != url]
+
+    r = client.post("/api/apprise-urls", json={"url": url})
+    assert r.status_code == 200, r.text
+    assert url in r.json()["apprise_urls"]
+
+    encoded = urllib.parse.quote(url, safe="")
+    r = client.request("DELETE", f"/api/apprise-urls/{encoded}")
+    assert r.status_code == 200
+    assert url not in r.json()["apprise_urls"]
+
+
+# ── Optional HTTP Basic auth ────────────────────────────────────
+def test_auth_enforced_when_configured(monkeypatch):
+    monkeypatch.setenv("WEB_USERNAME", "user")
+    monkeypatch.setenv("WEB_PASSWORD", "pass")
+    monkeypatch.setenv("APPRISE_URL", "json://localhost/")
+    try:
+        reloaded = importlib.reload(main)
+        c = TestClient(reloaded.app)
+        # Health stays open for the Docker healthcheck.
+        assert c.get("/api/health").status_code == 200
+        # A protected endpoint requires credentials.
+        assert c.get("/api/config").status_code == 401
+        assert c.get("/api/config", auth=("user", "pass")).status_code == 200
+        assert c.get("/api/config", auth=("user", "wrong")).status_code == 401
+    finally:
+        # Restore the no-auth module state for any later tests.
+        monkeypatch.delenv("WEB_USERNAME", raising=False)
+        monkeypatch.delenv("WEB_PASSWORD", raising=False)
+        importlib.reload(main)


### PR DESCRIPTION
Adds `TestClient` coverage for the route layer, which previously had **no tests** (only `utils/testflight.py` was covered). Independent of the other open PRs — based directly on `pre-release`.

## Coverage (`tests/test_api.py`)
- **Read endpoints** — `/api/health` (open + well-formed), `/api/metrics`, `/api/testflight-ids`, `/api/apprise-urls`.
- **Input validation** — `/api/logs` limit bounds (`<1` and `>1000` → 400); invalid-format ID validates without a network call.
- **Add/remove flows** — add + remove a TestFlight ID and an Apprise URL, with the network validation, `.env` writer, and notifier monkeypatched so tests are hermetic; 404 on removing an unknown ID.
- **Optional auth** — reloads the app with `WEB_USERNAME`/`WEB_PASSWORD` set and asserts `/api/config` requires credentials while `/api/health` stays open (then reloads back so later tests are unaffected).

## Notes
- Tests avoid real network and `.env` writes via monkeypatch, so they're deterministic and offline.
- Declares `httpx` in `tests/requirements-test.txt` (required by Starlette's TestClient).
- Assertions are kept base-agnostic, so they also pass on the stacked PRs (#22 Pydantic models, #23 module split).

## Result
- Full suite: **25 passed** (15 existing + 10 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)