### PR TITLE
Extract logging setup into utils/web_logging.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - **Non-root container** - The Docker image now runs as an unprivileged user (uid 10001) instead of root.
 - **Non-blocking notifications** - The heartbeat loop and the stop/restart endpoints now send notifications via the async helper so a slow notification service no longer stalls the event loop.
 - **Typed request models** - The TestFlight ID and Apprise URL endpoints now use Pydantic request models instead of manual JSON parsing, giving proper request validation and accurate schemas in the auto-generated API docs at `/docs`.
-- **Module split** - Began breaking up the `main.py` monolith: extracted the metrics collector into `utils/metrics.py` and the Apprise service-icon lookup into `utils/service_icons.py` (behaviour unchanged), trimming `main.py` by ~260 lines.
+- **Module split** - Began breaking up the `main.py` monolith: extracted the metrics collector into `utils/metrics.py`, the Apprise service-icon lookup into `utils/service_icons.py`, and the logging setup / in-memory log buffer into `utils/web_logging.py` (behaviour unchanged), trimming `main.py` by ~390 lines.
 - **Cleanup** - Removed duplicate `_http_session`, `_session_lock`, and `_circuit_breaker_timeout` global declarations, the unused circuit-breaker helpers (`is_circuit_breaker_open` / `record_request_*`, never wired into the request path — the `/api/health` `circuit_breaker` field is gone), and the unused `check_multiple_testflight_urls` utility.
 
 ---

--- a/main.py
+++ b/main.py
@@ -8,10 +8,8 @@ import threading
 import logging
 import signal
 import random
-import itertools
 import secrets
 import time
-from collections import deque
 from contextlib import asynccontextmanager
 from fastapi import FastAPI, HTTPException, Form, Request, Depends
 from fastapi.responses import HTMLResponse, RedirectResponse
@@ -42,6 +40,14 @@ from utils.testflight import (
 )
 from utils.metrics import MetricsCollector
 from utils.service_icons import get_apprise_service_icon
+from utils.web_logging import (
+    configure_logging,
+    ensure_web_handler_attached,
+    get_recent_logs,
+    get_uvicorn_log_config,
+    log_entries,
+    log_entries_lock,
+)
 
 # Load .env before any os.getenv() calls so all variables see the file values
 load_dotenv()
@@ -210,142 +216,11 @@ HEARTBEAT_INTERVAL = (
 
 
 
-# Configure logging with colored output
-class ColoredFormatter(logging.Formatter):
-    """Custom formatter that adds color to log levels in console."""
+# Configure colored console logging (see utils/web_logging.py).
+configure_logging(__version__)
 
-    # ANSI color codes
-    COLORS = {
-        'DEBUG': '\033[36m',      # Cyan
-        'INFO': '\033[90m',       # Gray
-        'WARNING': '\033[93m',    # Yellow
-        'ERROR': '\033[91m',      # Red
-        'CRITICAL': '\033[91m',   # Red (same as ERROR)
-    }
-    RESET = '\033[0m'            # Reset color
-
-    def format(self, record):
-        # Get the log level color
-        levelname = record.levelname
-        color = self.COLORS.get(levelname, self.RESET)
-
-        # Color the level name
-        record.levelname = f"{color}{levelname}{self.RESET}"
-
-        # Format the message
-        return super().format(record)
-
-
-format_str = f"%(asctime)s - %(levelname)s - %(message)s [v{__version__}]"
-
-# Create console handler with colored formatter
-console_handler = logging.StreamHandler()
-console_handler.setFormatter(ColoredFormatter(format_str))
-
-# Configure logging - use force=True to avoid duplicate basicConfig issues
-# Don't pass handlers here, we'll configure manually
-logging.basicConfig(level=logging.INFO, force=True)
-
-# Clear any default handlers and add only our custom one
-root_logger = logging.getLogger()
-root_logger.handlers.clear()
-root_logger.addHandler(console_handler)
-root_logger.setLevel(logging.INFO)
-
-# Prevent propagation in child loggers that might have their own handlers
-logging.getLogger("uvicorn").propagate = True
-logging.getLogger("uvicorn.error").propagate = True
-logging.getLogger("uvicorn.access").propagate = True
-
-# Web logging handler to capture logs for web interface
-log_entries: deque = deque(maxlen=100)  # Keep last 100 log entries
-log_entries_lock = threading.Lock()  # Thread safety for log access
+# Timestamp used for uptime reporting in the dashboard.
 app_start_time = datetime.now()
-
-
-class WebLogHandler(logging.Handler):
-    def emit(self, record):
-        log_entry = {
-            "timestamp": datetime.fromtimestamp(record.created).strftime(
-                "%Y-%m-%d %H:%M:%S"
-            ),
-            "level": record.levelname,
-            "message": record.getMessage(),
-        }
-        with log_entries_lock:
-            log_entries.append(log_entry)
-
-
-def get_recent_logs(limit: int = 20) -> list:
-    """Thread-safe function to get recent log entries."""
-    with log_entries_lock:
-        total_entries = len(log_entries)
-        if total_entries == 0:
-            return []
-
-        # Use efficient slicing for better performance
-        start_idx = max(0, total_entries - limit)
-        return list(itertools.islice(log_entries, start_idx, total_entries))
-
-
-# Add the web log handler to the root logger (will be attached in ensure_web_handler_attached)
-web_handler = WebLogHandler()
-_web_handler_attached = False  # Track if web handler has been attached
-
-
-def ensure_web_handler_attached():
-    """
-    Ensure WebLogHandler is attached to all relevant loggers.
-    This is called after uvicorn initializes to make sure our handler
-    captures all logs including uvicorn logs.
-    """
-    global _web_handler_attached
-    
-    if _web_handler_attached:
-        return  # Already attached, don't add again
-    
-    # Only attach to root logger - handlers propagate to child loggers
-    root_logger = logging.getLogger()
-    
-    # Double-check no duplicate WebLogHandlers exist
-    for handler in root_logger.handlers:
-        if isinstance(handler, WebLogHandler):
-            _web_handler_attached = True
-            logging.debug("WebLogHandler already present on root logger")
-            return
-    
-    # Add web handler
-    root_logger.addHandler(web_handler)
-    _web_handler_attached = True
-    logging.debug("WebLogHandler attached to root logger")
-
-
-# Custom uvicorn log config that preserves our formatting
-def get_uvicorn_log_config():
-    """
-    Create a uvicorn log config that uses our existing logging setup.
-
-    This prevents uvicorn from reconfiguring logging while still allowing
-    it to log properly through our configured handlers.
-    """
-    return {
-        "version": 1,
-        "disable_existing_loggers": False,  # Keep our handlers!
-        "formatters": {
-            "default": {
-                "format": format_str,
-            },
-        },
-        "handlers": {},  # Don't create any new handlers - use root logger
-        "loggers": {
-            "uvicorn": {"level": "INFO", "propagate": True},
-            "uvicorn.error": {"level": "INFO", "propagate": True},
-            "uvicorn.access": {"level": "INFO", "propagate": True},
-        },
-        "root": {
-            "level": "INFO",
-        },
-    }
 
 
 # Validate environment variables

--- a/utils/web_logging.py
+++ b/utils/web_logging.py
@@ -1,0 +1,157 @@
+"""
+Logging configuration and in-memory log buffer for the web dashboard.
+
+Provides colored console logging, a bounded ring buffer of recent log entries
+surfaced by the dashboard, and a uvicorn log config that reuses our handlers.
+Call :func:`configure_logging` once at startup before logging anything that
+should carry the version suffix.
+"""
+
+import itertools
+import logging
+import threading
+from collections import deque
+from datetime import datetime
+
+# In-memory ring buffer of recent log entries for the web UI.
+log_entries: deque = deque(maxlen=100)  # Keep last 100 log entries
+log_entries_lock = threading.Lock()  # Thread safety for log access
+
+# Set by configure_logging() so the format can include the app version.
+_format_str = "%(asctime)s - %(levelname)s - %(message)s"
+
+
+# Configure logging with colored output
+class ColoredFormatter(logging.Formatter):
+    """Custom formatter that adds color to log levels in console."""
+
+    # ANSI color codes
+    COLORS = {
+        'DEBUG': '\033[36m',      # Cyan
+        'INFO': '\033[90m',       # Gray
+        'WARNING': '\033[93m',    # Yellow
+        'ERROR': '\033[91m',      # Red
+        'CRITICAL': '\033[91m',   # Red (same as ERROR)
+    }
+    RESET = '\033[0m'            # Reset color
+
+    def format(self, record):
+        # Get the log level color
+        levelname = record.levelname
+        color = self.COLORS.get(levelname, self.RESET)
+
+        # Color the level name
+        record.levelname = f"{color}{levelname}{self.RESET}"
+
+        # Format the message
+        return super().format(record)
+
+
+class WebLogHandler(logging.Handler):
+    def emit(self, record):
+        log_entry = {
+            "timestamp": datetime.fromtimestamp(record.created).strftime(
+                "%Y-%m-%d %H:%M:%S"
+            ),
+            "level": record.levelname,
+            "message": record.getMessage(),
+        }
+        with log_entries_lock:
+            log_entries.append(log_entry)
+
+
+def get_recent_logs(limit: int = 20) -> list:
+    """Thread-safe function to get recent log entries."""
+    with log_entries_lock:
+        total_entries = len(log_entries)
+        if total_entries == 0:
+            return []
+
+        # Use efficient slicing for better performance
+        start_idx = max(0, total_entries - limit)
+        return list(itertools.islice(log_entries, start_idx, total_entries))
+
+
+# The web log handler is attached lazily in ensure_web_handler_attached().
+web_handler = WebLogHandler()
+_web_handler_attached = False  # Track if web handler has been attached
+
+
+def configure_logging(version: str) -> None:
+    """Set up colored console logging. Call once at startup."""
+    global _format_str
+    _format_str = f"%(asctime)s - %(levelname)s - %(message)s [v{version}]"
+
+    # Create console handler with colored formatter
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(ColoredFormatter(_format_str))
+
+    # Configure logging - use force=True to avoid duplicate basicConfig issues
+    # Don't pass handlers here, we'll configure manually
+    logging.basicConfig(level=logging.INFO, force=True)
+
+    # Clear any default handlers and add only our custom one
+    root_logger = logging.getLogger()
+    root_logger.handlers.clear()
+    root_logger.addHandler(console_handler)
+    root_logger.setLevel(logging.INFO)
+
+    # Prevent propagation in child loggers that might have their own handlers
+    logging.getLogger("uvicorn").propagate = True
+    logging.getLogger("uvicorn.error").propagate = True
+    logging.getLogger("uvicorn.access").propagate = True
+
+
+def ensure_web_handler_attached():
+    """
+    Ensure WebLogHandler is attached to all relevant loggers.
+    This is called after uvicorn initializes to make sure our handler
+    captures all logs including uvicorn logs.
+    """
+    global _web_handler_attached
+
+    if _web_handler_attached:
+        return  # Already attached, don't add again
+
+    # Only attach to root logger - handlers propagate to child loggers
+    root_logger = logging.getLogger()
+
+    # Double-check no duplicate WebLogHandlers exist
+    for handler in root_logger.handlers:
+        if isinstance(handler, WebLogHandler):
+            _web_handler_attached = True
+            logging.debug("WebLogHandler already present on root logger")
+            return
+
+    # Add web handler
+    root_logger.addHandler(web_handler)
+    _web_handler_attached = True
+    logging.debug("WebLogHandler attached to root logger")
+
+
+# Custom uvicorn log config that preserves our formatting
+def get_uvicorn_log_config():
+    """
+    Create a uvicorn log config that uses our existing logging setup.
+
+    This prevents uvicorn from reconfiguring logging while still allowing
+    it to log properly through our configured handlers.
+    """
+    return {
+        "version": 1,
+        "disable_existing_loggers": False,  # Keep our handlers!
+        "formatters": {
+            "default": {
+                "format": _format_str,
+            },
+        },
+        "handlers": {},  # Don't create any new handlers - use root logger
+        "loggers": {
+            "uvicorn": {"level": "INFO", "propagate": True},
+            "uvicorn.error": {"level": "INFO", "propagate": True},
+            "uvicorn.access": {"level": "INFO", "propagate": True},
+        },
+        "root": {
+            "level": "INFO",
+        },
+    }


### PR DESCRIPTION
Continues the `main.py` split (stacked on #23). Behaviour-identical, and verified against the new API tests from #24.

## What moves to `utils/web_logging.py`
- `ColoredFormatter` (console colors)
- `WebLogHandler` + the in-memory `log_entries` ring buffer + `log_entries_lock`
- `get_recent_logs`
- `web_handler` instance + lazy `ensure_web_handler_attached`
- `get_uvicorn_log_config`

The version-stamped format string is now built inside a new `configure_logging(version)` function (called once from `main.py` at startup) instead of a module-level `format_str` that read `__version__` directly — that was the only thing coupling this code to `main.py`.

Also drops the now-unused `itertools` / `deque` imports from `main.py`.

## Result
`main.py` is down to ~1,790 lines (from ~2,180 before the split started). `app_start_time` stays in `main.py` (it's app-level, not logging).

## Testing
- Full suite **15 passed**; with the #24 API tests temporarily layered in, **25 passed** — confirms the route layer (incl. `/api/logs`) is unaffected.
- Verified web-log capture end-to-end: with the lifespan active, a `logging.info(...)` call shows up in `/api/logs`, and `get_uvicorn_log_config()` still carries the `[vX.Y.Z]` suffix.

## Remaining
Routes and config/env handling are still in `main.py` — the next (and largest) slice. Best tackled once #24 (API tests) is merged so it runs in CI against the refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)