### PR TITLE
Disable heartbeat when HEARTBEAT_INTERVAL=0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - **Localhost by default** - `FASTAPI_HOST` now defaults to `127.0.0.1` instead of `0.0.0.0`, so the dashboard (which can read/write `.env` and stop/restart the process) is not exposed on all interfaces by accident. A startup warning is logged when bound to a non-loopback host without credentials.
 
 ### Bug Fixes
+- **Stop/Restart buttons** - The dashboard's confirm dialog cleared its callback before invoking it, so confirming Stop/Restart closed the modal without doing anything. The action now runs as expected.
+- **Heartbeat disable** - `HEARTBEAT_INTERVAL=0` is documented as "disable", but the code did `sleep(0)` in a loop and busy-spun, flooding notifications. It now disables the heartbeat as documented.
+- **Missing `jinja2` dependency** - Added `jinja2` to `requirements.txt`; the dashboard's `Jinja2Templates` need it, but a fresh install previously crashed on startup with `ImportError`.
 - **Docker healthcheck** - Replaced the `requests`-based healthcheck (an undeclared dependency that left the container permanently `unhealthy`) with a stdlib `urllib` check that exits non-zero on failure.
 - **Graceful shutdown** - Signal handlers were registered at import time on an event loop that `asyncio.run()` never used, so `SIGTERM` (e.g. `docker stop`) skipped cleanup. They are now attached to the running loop in `async_main()`.
 - **Restart from the dashboard** - Now re-executes in place via `os.execv` instead of spawning a child process. The previous approach spawned a child that died with the container (so restart did nothing under Docker). Also warns when `FASTAPI_PORT` is unset, since the dashboard could otherwise return on a different random port.

--- a/main.py
+++ b/main.py
@@ -309,6 +309,12 @@ async def watch():
 
 async def heartbeat():
     """Send periodic heartbeat notifications."""
+    # HEARTBEAT_INTERVAL <= 0 disables the heartbeat entirely (see README /
+    # .env.example). Without this guard, sleep(0) would busy-loop and flood
+    # notifications.
+    if HEARTBEAT_INTERVAL <= 0:
+        logging.info("Heartbeat disabled (HEARTBEAT_INTERVAL=0)")
+        return
     try:
         while True:
             current_time = format_datetime(datetime.now())


### PR DESCRIPTION
`HEARTBEAT_INTERVAL=0` is documented (README + `.env.example`) as disabling the heartbeat, but the loop did:

```python
while True:
    await send_notification_async(...)
    await asyncio.sleep(HEARTBEAT_INTERVAL)   # sleep(0) -> tight loop
```

With `0`, `sleep(0)` yields immediately, so the task **busy-loops and floods notifications** instead of disabling. Now `heartbeat()` returns early (logging "Heartbeat disabled") when the interval is `<= 0`.

Also backfills CHANGELOG entries for the Stop/Restart fix and the `jinja2` dependency that shipped in #31.

## Testing
- Reproduced: ran with `HEARTBEAT_INTERVAL=0` — log shows `Heartbeat disabled` once and **zero** heartbeat notifications (was flooding before).
- Full suite **25 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)