### PR TITLE
Require authentication for public dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ All configuration is done through environment variables in the `.env` file. You 
 
 > **Note:** `UI_THEME` sets the server-side default for new visitors. Each browser can override it independently via the theme toggle in the dashboard — the preference is saved in `localStorage`.
 
-> **🔒 Security:** The dashboard can read/write your `.env` (which contains your notification secrets) and stop/restart the process. It binds to `127.0.0.1` by default for that reason. If you expose it (`FASTAPI_HOST=0.0.0.0`, e.g. in Docker), set `WEB_USERNAME` and `WEB_PASSWORD` to require a login. `/api/health` stays open for health checks.
+> **🔒 Security:** The dashboard can read/write your `.env` (which contains your notification secrets) and stop/restart the process. It binds to `127.0.0.1` by default for that reason. If you expose it on a non-loopback address (`FASTAPI_HOST=0.0.0.0`, e.g. in Docker), **authentication is required**: `WEB_USERNAME` and `WEB_PASSWORD` must both be set, otherwise the app refuses to start and exits with code `1`. On `127.0.0.1`/`localhost` auth is optional. `/api/health` stays open for health checks.
 
 ### Example `.env` File
 

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import asyncio
 import uvicorn
 import threading
@@ -62,6 +63,31 @@ enable_status_cache(ttl_seconds=300)
 # re-read when the module is reloaded, e.g. in tests.
 WEB_USERNAME = os.getenv("WEB_USERNAME", "").strip()
 WEB_PASSWORD = os.getenv("WEB_PASSWORD", "").strip()
+
+# Hosts considered local, where authentication is optional. Any other bind
+# address is treated as publicly reachable and requires credentials.
+LOOPBACK_HOSTS = ("127.0.0.1", "localhost", "::1")
+
+
+def validate_auth_config():
+    """Require dashboard authentication when bound to a non-loopback host.
+
+    If FASTAPI_HOST is a public address (anything other than localhost), both
+    WEB_USERNAME and WEB_PASSWORD must be set. When they are missing, log an
+    error and exit with status 1 rather than starting an unprotected,
+    publicly reachable dashboard.
+    """
+    host = os.getenv("FASTAPI_HOST", "127.0.0.1")
+    if host in LOOPBACK_HOSTS:
+        return
+    if not (WEB_USERNAME and WEB_PASSWORD):
+        logging.error(
+            "Refusing to start: FASTAPI_HOST=%s exposes the dashboard publicly, "
+            "but WEB_USERNAME and WEB_PASSWORD are not set. Set both to require "
+            "a login, or bind to 127.0.0.1.",
+            host,
+        )
+        sys.exit(1)
 
 
 # Status tracking for change notifications
@@ -357,16 +383,6 @@ async def start_fastapi():
         default_host = os.getenv("FASTAPI_HOST", "127.0.0.1")
         default_port = int(os.getenv("FASTAPI_PORT", random.randint(8000, 9000)))
 
-        if default_host not in ("127.0.0.1", "localhost", "::1") and not (
-            WEB_USERNAME and WEB_PASSWORD
-        ):
-            logging.warning(
-                "Web dashboard is bound to %s without WEB_USERNAME/WEB_PASSWORD "
-                "set. Anyone who can reach this port can read your .env secrets "
-                "and control the process. Set credentials to enable auth.",
-                default_host,
-            )
-
         logging.info(f"Starting FastAPI server on {default_host}:{default_port}")
 
         config = uvicorn.Config(
@@ -404,6 +420,7 @@ async def start_fastapi():
 
 def main():
     """Main function to start all tasks."""
+    validate_auth_config()
     try:
         asyncio.run(async_main())
     except KeyboardInterrupt:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -137,3 +137,32 @@ def test_auth_enforced_when_configured(monkeypatch):
         monkeypatch.delenv("WEB_USERNAME", raising=False)
         monkeypatch.delenv("WEB_PASSWORD", raising=False)
         importlib.reload(main)
+
+
+# ── Auth required on a public bind address ──────────────────────
+def test_public_host_without_credentials_exits(monkeypatch):
+    """A non-loopback host with no credentials must abort startup (exit 1)."""
+    monkeypatch.setenv("FASTAPI_HOST", "0.0.0.0")
+    monkeypatch.setattr(main, "WEB_USERNAME", "")
+    monkeypatch.setattr(main, "WEB_PASSWORD", "")
+    with pytest.raises(SystemExit) as exc:
+        main.validate_auth_config()
+    assert exc.value.code == 1
+
+
+def test_public_host_with_credentials_ok(monkeypatch):
+    """A non-loopback host is allowed when both credentials are set."""
+    monkeypatch.setenv("FASTAPI_HOST", "0.0.0.0")
+    monkeypatch.setattr(main, "WEB_USERNAME", "user")
+    monkeypatch.setattr(main, "WEB_PASSWORD", "pass")
+    # Should not raise.
+    main.validate_auth_config()
+
+
+def test_loopback_host_without_credentials_ok(monkeypatch):
+    """Auth is optional on localhost, even with no credentials."""
+    monkeypatch.setattr(main, "WEB_USERNAME", "")
+    monkeypatch.setattr(main, "WEB_PASSWORD", "")
+    for host in ("127.0.0.1", "localhost", "::1"):
+        monkeypatch.setenv("FASTAPI_HOST", host)
+        main.validate_auth_config()  # should not raise


### PR DESCRIPTION
**Runbook 01 — Security Hardening, Task 1 only.** (Per the runbook: one task, no unrelated refactors, commit and stop. Left unmerged for review.)

## Behavior
- `FASTAPI_HOST` on a **non-loopback** address (e.g. `0.0.0.0`) now **requires** both `WEB_USERNAME` and `WEB_PASSWORD`.
- If they're missing, `validate_auth_config()` (called at startup in `main()`) logs an error and **exits with code 1** instead of serving an unprotected dashboard.
- On `127.0.0.1` / `localhost` / `::1`, auth stays optional.
- Replaces the previous non-fatal warning in `start_fastapi`.

## Deliverables
- **Startup validation** — `validate_auth_config()` in `main.py`.
- **README** — security note updated to say it refuses to start (exit 1) on a public host without credentials.
- **Unit tests** — public-without-creds → `SystemExit(1)`; public-with-creds → ok; loopback hosts without creds → ok.

## Testing
- Full suite **28 passed** (25 + 3 new).
- Live: `python main.py` with `FASTAPI_HOST=0.0.0.0` and no creds exits `1` with a clear message; with creds it starts and enforces auth (config `401` without, `200` with; `/api/health` stays open).

⚠️ **Unrelated bug noticed (not touched, per the runbook):** with the heartbeat fix from #32, `HEARTBEAT_INTERVAL=0` makes the heartbeat task return immediately, which trips `async_main`'s `FIRST_COMPLETED` wait and shuts the app down right after startup. Worth a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)