### PR TITLE
Fix disabled heartbeat shutdown bug

### DIFF
--- a/main.py
+++ b/main.py
@@ -309,11 +309,13 @@ async def watch():
 
 async def heartbeat():
     """Send periodic heartbeat notifications."""
-    # HEARTBEAT_INTERVAL <= 0 disables the heartbeat entirely (see README /
-    # .env.example). Without this guard, sleep(0) would busy-loop and flood
-    # notifications.
+    # HEARTBEAT_INTERVAL <= 0 disables the heartbeat (see README / .env.example).
+    # Wait for shutdown instead of returning: a sleep(0) loop would busy-spin and
+    # flood notifications, while returning immediately would complete this task
+    # and trip async_main's FIRST_COMPLETED wait, shutting the app down at startup.
     if HEARTBEAT_INTERVAL <= 0:
         logging.info("Heartbeat disabled (HEARTBEAT_INTERVAL=0)")
+        await shutdown_event.wait()
         return
     try:
         while True:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,6 +7,7 @@ cover the read endpoints, input validation, the add/remove flows, and the
 optional HTTP Basic auth.
 """
 
+import asyncio
 import importlib
 import os
 import urllib.parse
@@ -137,3 +138,26 @@ def test_auth_enforced_when_configured(monkeypatch):
         monkeypatch.delenv("WEB_USERNAME", raising=False)
         monkeypatch.delenv("WEB_PASSWORD", raising=False)
         importlib.reload(main)
+
+
+# ── Disabled heartbeat must not exit immediately ────────────────
+def test_disabled_heartbeat_waits_for_shutdown(monkeypatch):
+    """With HEARTBEAT_INTERVAL=0 the heartbeat task must stay alive until
+    shutdown_event is set, so it doesn't trip async_main's FIRST_COMPLETED."""
+    monkeypatch.setattr(main, "HEARTBEAT_INTERVAL", 0)
+
+    async def run():
+        ev = asyncio.Event()
+        monkeypatch.setattr(main, "shutdown_event", ev)
+
+        task = asyncio.create_task(main.heartbeat())
+        await asyncio.sleep(0.05)
+        # Must NOT have returned immediately.
+        assert not task.done()
+
+        # Setting shutdown lets it finish cleanly (no exception).
+        ev.set()
+        await asyncio.wait_for(task, timeout=1)
+        assert task.done() and task.exception() is None
+
+    asyncio.run(run())


### PR DESCRIPTION
Isolated bug fix (requested before continuing the security runbook).

## Bug
With `HEARTBEAT_INTERVAL=0`, `heartbeat()` returned immediately. Its task then completed, which tripped `async_main`'s `asyncio.wait(..., return_when=FIRST_COMPLETED)` — so the whole app shut down right after startup.

## Fix
The disabled-heartbeat branch now `await shutdown_event.wait()` before returning, so the task stays alive (and silent) until shutdown — without the busy-spin the `sleep(0)` loop had, and without completing early.

## Testing
- New test `test_disabled_heartbeat_waits_for_shutdown`: with `HEARTBEAT_INTERVAL=0`, the heartbeat task is **not done** after a tick, and finishes cleanly only once `shutdown_event` is set.
- Full suite **26 passed**.
- Live: ran with `HEARTBEAT_INTERVAL=0` — app stays up (`/api/health` `200` after 6s), **no** heartbeat spam, **no** startup shutdown.

Only `main.py` (heartbeat branch) and `tests/test_api.py` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)