### PR TITLE
Mask secrets in logs and dashboard

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -46,6 +46,7 @@ from utils.formatting import (
     app_icon_cache,
 )
 from utils.notifications import send_notification_async
+from utils.masking import mask_secret
 from utils.service_icons import get_apprise_service_icon
 from utils.web_logging import get_recent_logs, log_entries, log_entries_lock
 
@@ -350,26 +351,9 @@ async def get_apprise_urls():
     for url in urls:
         service_info = get_apprise_service_icon(url)
 
-        # Mask sensitive parts of URL for display
-        display_url = url
-        try:
-            # Try to parse as URL to mask credentials
-            if "://" in url:
-                parts = url.split("://", 1)
-                if len(parts) == 2:
-                    scheme = parts[0]
-                    rest = parts[1]
-                    # Look for @ symbol indicating credentials
-                    if "@" in rest:
-                        # Mask everything before @
-                        after_at = rest.split("@", 1)[1]
-                        display_url = f"{scheme}://***@{after_at}"
-                    # Hide query parameters for security
-                    if "?" in display_url:
-                        display_url = display_url.split("?")[0] + "?***"
-        except Exception:
-            # If parsing fails, show abbreviated version
-            display_url = url[:30] + "..." if len(url) > 30 else url
+        # Mask credentials/tokens for display (raw value kept in `url` for
+        # removal operations only).
+        display_url = mask_secret(url)
 
         urls_with_info.append(
             {

--- a/state.py
+++ b/state.py
@@ -28,6 +28,7 @@ from config import (
     TESTFLIGHT_URL,
 )
 from utils.formatting import format_datetime, format_link
+from utils.masking import mask_secret
 from utils.metrics import MetricsCollector
 from utils.notifications import send_notification, send_notification_async
 
@@ -316,7 +317,7 @@ def validate_apprise_url(url: str) -> tuple[bool, str]:
 
     except Exception as e:
         # Fallback to basic validation if Apprise validation fails
-        logging.warning(f"Apprise validation error for URL {url}: {e}")
+        logging.warning(f"Apprise validation error for URL {mask_secret(url)}: {e}")
 
         # Basic URL validation - should start with a protocol
         supported_protocols = [
@@ -527,10 +528,10 @@ def add_apprise_url(url: str) -> tuple[bool, str]:
             current_apprise_urls.append(url)
             # Add to the live Apprise object
             apobj.add(url)
-            logging.info(f"Added Apprise URL: {url}")
+            logging.info(f"Added Apprise URL: {mask_secret(url)}")
             # Send notification about the addition
             total_urls = len(current_apprise_urls)
-            msg = f"Apprise URL Added: {url} (Total: {total_urls} URLs)"
+            msg = f"Apprise URL Added: {mask_secret(url)} (Total: {total_urls} URLs)"
             send_notification(msg, apobj)
             return True, "Apprise URL added successfully"
         else:
@@ -550,10 +551,10 @@ def remove_apprise_url(url: str) -> tuple[bool, str]:
             apobj.clear()
             for remaining_url in current_apprise_urls:
                 apobj.add(remaining_url)
-            logging.info(f"Removed Apprise URL: {url}")
+            logging.info(f"Removed Apprise URL: {mask_secret(url)}")
             # Send notification about the removal
             total_urls = len(current_apprise_urls)
-            msg = f"Apprise URL Removed: {url} (Total: {total_urls} URLs)"
+            msg = f"Apprise URL Removed: {mask_secret(url)} (Total: {total_urls} URLs)"
             send_notification(msg, apobj)
             return True, "Apprise URL removed successfully"
         else:

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -1,0 +1,58 @@
+"""Tests for utils.masking.mask_secret."""
+
+from utils.masking import mask_secret
+
+
+def test_mask_discord_url():
+    raw = "discord://123456789012/abcdEFGHijklMNOPqrstUVWX"
+    masked = mask_secret(raw)
+    assert masked.startswith("discord://")
+    assert masked != raw
+    # The webhook id and token body must not be exposed.
+    assert "123456789012" not in masked
+    assert "abcdEFGHijklMNOP" not in masked
+
+
+def test_mask_telegram_url():
+    raw = "tgram://1234567890:ABCdefGhIjkLmNoToken/987654321"
+    masked = mask_secret(raw)
+    assert masked.startswith("tgram://")
+    assert masked != raw
+    assert "ABCdefGhIjkLmNoToken" not in masked
+
+
+def test_mask_slack_url():
+    raw = "slack://TokenA000/TokenB000/TokenC000Secret/channel"
+    masked = mask_secret(raw)
+    assert masked.startswith("slack://")
+    assert masked != raw
+    assert "TokenA000" not in masked
+    assert "TokenC000Secret" not in masked
+
+
+def test_mask_matrix_url():
+    raw = "matrix://user:Pass0rdSecret@matrix.example.org/!room"
+    masked = mask_secret(raw)
+    assert masked.startswith("matrix://")
+    assert masked != raw
+    assert "Pass0rdSecret" not in masked
+    assert "matrix.example.org" not in masked
+
+
+def test_mask_generic_webhook_url():
+    raw = "https://hooks.example.com/services/T000/B000/Xyz0123456789Secret"
+    masked = mask_secret(raw)
+    assert masked.startswith("https://")
+    assert masked != raw
+    # Host and token body are hidden.
+    assert "hooks.example.com" not in masked
+    assert "Xyz0123456789Secret" not in masked
+
+
+def test_plain_text_unchanged():
+    text = "Beta is now OPEN for new testers"
+    assert mask_secret(text) == text
+
+
+def test_non_string_unchanged():
+    assert mask_secret(None) is None

--- a/utils/masking.py
+++ b/utils/masking.py
@@ -1,0 +1,29 @@
+"""Helpers for masking secret-bearing values.
+
+Apprise notification URLs embed tokens, passwords, and webhook secrets. Use
+:func:`mask_secret` whenever such a value is surfaced to a user — in logs,
+dashboard output, notifications, or API responses. Raw values are kept only in
+configuration storage (the .env file and the in-memory URL list).
+"""
+
+
+def mask_secret(value: str) -> str:
+    """Mask credentials in a secret-bearing URL for safe display/logging.
+
+    Keeps the scheme (so the service stays identifiable) and the last few
+    characters (so entries remain distinguishable), masking everything in
+    between. Plain (non-URL) text is returned unchanged.
+
+    Examples:
+        discord://id/token         -> discord://******oken
+        tgram://bot_token/chat_id  -> tgram://******t_id
+        https://host/hook/secret   -> https://******cret
+        "Beta is now OPEN"         -> "Beta is now OPEN"   (unchanged)
+    """
+    if not isinstance(value, str) or "://" not in value:
+        return value
+    scheme, sep, rest = value.partition("://")
+    if not rest:
+        return value
+    tail = rest[-4:] if len(rest) > 4 else ""
+    return f"{scheme}{sep}{'*' * 6}{tail}"


### PR DESCRIPTION
**Runbook 01 — Security Hardening, Task 2 only.** (One task; no unrelated refactors; commit and stop. Left unmerged for review.)

## Shared helper
New `utils/masking.py` → `mask_secret(value)`: keeps the URL scheme (service stays identifiable) and the last 4 characters (entries stay distinguishable), masks everything in between; returns plain non-URL text unchanged.

## Applied where secrets surfaced
- **Logs** — `state.py` add/remove/validation log lines.
- **Notifications** — the "Apprise URL Added/Removed" messages.
- **Dashboard / API output** — `display_url` in `GET /api/apprise-urls` now uses the helper. The previous ad-hoc masking only handled `user:pass@` and `?query`, so token-in-path URLs like `discord://id/token` and `tgram://token/chat` were shown **in full**. Now masked.
- **`/api/logs`** — covered transitively, since entries are masked at the source.

## Not masked (by design)
Raw values remain in **configuration storage** (`.env` and the in-memory list). `GET /api/apprise-urls` still returns the raw `url` field **solely so the dashboard can remove an entry** (the DELETE endpoint is keyed by URL); the human-facing `display_url` is masked. `GET /api/config` (the raw `.env` editor) is auth-protected config storage and left as-is.

## Tests
- `tests/test_masking.py`: Discord, Telegram, generic webhook, plain text, non-string.
- Full suite **34 passed**.
- Integration check: `/api/apprise-urls` returns `display_url=discord://******DEFG` while the raw `url` is preserved for removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)