### PR TITLE
Improve .env editing reliability

### DIFF
--- a/state.py
+++ b/state.py
@@ -123,10 +123,32 @@ def get_current_apprise_urls():
 
 
 def update_env_file(key: str, new_values: list[str]):
-    """Safely update the .env file with new values for a given key."""
+    """Safely update the .env file with new values for a given key.
+
+    Validates inputs first, preserves all other lines (comments and ordering),
+    writes to a temporary file in the same directory, backs up the previous
+    version to ``.env.bak``, and atomically replaces the original. Returns
+    False without modifying the file if validation fails.
+    """
+    import re
+    import shutil
+    import tempfile
+
+    env_path = ".env"
+    backup_path = ".env.bak"
+
+    # Validate before writing; abort (without touching the file) on failure.
+    if not isinstance(key, str) or not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", key):
+        logging.error("Refusing to update .env: invalid key %r", key)
+        return False
+    if not isinstance(new_values, list) or any(
+        not isinstance(v, str) or "\n" in v or "\r" in v for v in new_values
+    ):
+        logging.error("Refusing to update .env: values must be newline-free strings")
+        return False
+
     try:
         # Read current .env content
-        env_path = ".env"
         if not os.path.exists(env_path):
             logging.error("Cannot update .env file: file does not exist")
             return False
@@ -177,9 +199,20 @@ def update_env_file(key: str, new_values: list[str]):
             else:
                 lines.append(f"{key}=\n")
 
-        # Write back to file atomically
-        with open(env_path, "w") as f:
-            f.writelines(lines)
+        # Write atomically: temp file in the same directory, fsync, back up the
+        # previous version, then os.replace() onto the original.
+        env_dir = os.path.dirname(os.path.abspath(env_path)) or "."
+        fd, tmp_path = tempfile.mkstemp(prefix=".env.", suffix=".tmp", dir=env_dir)
+        try:
+            with os.fdopen(fd, "w") as tmp:
+                tmp.writelines(lines)
+                tmp.flush()
+                os.fsync(tmp.fileno())
+            shutil.copy2(env_path, backup_path)
+            os.replace(tmp_path, env_path)
+        finally:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
 
         logging.info(f"Updated .env file with {len(new_values)} {key} values")
         return True

--- a/tests/test_env_file.py
+++ b/tests/test_env_file.py
@@ -1,0 +1,63 @@
+"""Tests for state.update_env_file hardening (validate / atomic / backup)."""
+
+import os
+
+os.environ.setdefault("APPRISE_URL", "json://localhost/")
+
+import state  # noqa: E402
+
+
+def test_update_preserves_comments_order_and_backs_up(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    env = tmp_path / ".env"
+    env.write_text(
+        "# header comment\n"
+        "APPRISE_URL=discord://a/b,\n"
+        "ID_LIST=abc123,\n"
+        "\n"
+        "# trailing comment\n"
+        "HEARTBEAT_INTERVAL=6\n"
+    )
+
+    assert state.update_env_file("ID_LIST", ["abc123", "def456"]) is True
+
+    content = env.read_text()
+    # Comments preserved.
+    assert "# header comment" in content
+    assert "# trailing comment" in content
+    # Ordering of the surrounding keys preserved.
+    assert (
+        content.index("APPRISE_URL=")
+        < content.index("ID_LIST=")
+        < content.index("HEARTBEAT_INTERVAL=")
+    )
+    # New value written.
+    assert "def456" in content
+    # Backup holds the previous version (atomic replace left a .env.bak).
+    backup = tmp_path / ".env.bak"
+    assert backup.exists()
+    assert "def456" not in backup.read_text()
+    # No leftover temp files.
+    assert not [p for p in tmp_path.iterdir() if p.name.endswith(".tmp")]
+
+
+def test_update_aborts_on_invalid_key(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    env = tmp_path / ".env"
+    original = "ID_LIST=abc,\n"
+    env.write_text(original)
+
+    assert state.update_env_file("bad key!", ["x"]) is False
+    # File untouched and no backup written.
+    assert env.read_text() == original
+    assert not (tmp_path / ".env.bak").exists()
+
+
+def test_update_aborts_on_newline_value(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    env = tmp_path / ".env"
+    original = "ID_LIST=abc,\n"
+    env.write_text(original)
+
+    assert state.update_env_file("ID_LIST", ["x\ny"]) is False
+    assert env.read_text() == original


### PR DESCRIPTION
**Runbook 01 — Security Hardening, Task 3 only.** (One task; no unrelated refactors; commit and stop. Left unmerged for review.)

Hardens `update_env_file` in `state.py` — the structured `.env` writer used by add/remove of TestFlight IDs and Apprise URLs.

## Changes
- **Validate before writing** — reject an invalid key (not `[A-Za-z_][A-Za-z0-9_]*`) or any value containing a newline; return `False` **without touching the file**.
- **Temporary file** — write the new content to `tempfile.mkstemp(dir=<same dir>)`, `flush()` + `os.fsync()`.
- **Atomic replace** — `os.replace(tmp, .env)` (same filesystem → atomic swap; no partially-written file on crash).
- **Backup** — copy the previous `.env` to `.env.bak` (via `shutil.copy2`) before replacing.
- **Preserve comments + ordering** — unchanged behavior: only the target key's line(s) are rewritten; every other line (comments, blank lines, other keys) stays in place.

The temp file is cleaned up if anything fails before the swap, so a failure leaves the original `.env` intact.

## Scope
Only the structured writer is touched. The raw full-content dashboard editor (`/api/config` → `save_config`) is a separate feature (user supplies the entire file, so comment/order preservation is inherent) and already creates a backup — left as-is to avoid unrelated changes.

## Tests
`tests/test_env_file.py`:
- comments + key ordering preserved, new value written, `.env.bak` holds the previous version, no leftover temp files;
- aborts (file untouched, no backup) on an invalid key;
- aborts on a value containing a newline.

Full suite: **39 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)