### PR TITLE
Add CSRF protection

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ import random
 import secrets
 from contextlib import asynccontextmanager
 from fastapi import FastAPI, HTTPException, Request, Depends
+from fastapi.responses import JSONResponse
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from fastapi.staticfiles import StaticFiles
 from datetime import datetime
@@ -213,6 +214,51 @@ def require_auth(
 # FastAPI server
 app = FastAPI(lifespan=lifespan, dependencies=[Depends(require_auth)])
 app.mount("/static", StaticFiles(directory="static"), name="static")
+
+
+# --- CSRF protection (double-submit cookie) ----------------------------------
+CSRF_COOKIE = "csrf_token"
+CSRF_HEADER = "x-csrf-token"
+CSRF_SAFE_METHODS = {"GET", "HEAD", "OPTIONS", "TRACE"}
+
+
+def _issue_csrf_cookie(response, existing):
+    """Set a CSRF cookie on the response if the client doesn't have one yet."""
+    if not existing:
+        response.set_cookie(
+            CSRF_COOKIE,
+            secrets.token_urlsafe(32),
+            samesite="strict",
+            httponly=False,  # readable by JS so it can echo the value in a header
+            path="/",
+        )
+
+
+@app.middleware("http")
+async def csrf_protect(request: Request, call_next):
+    """Require a matching CSRF token on every state-changing request.
+
+    Double-submit-cookie pattern: the browser holds a ``csrf_token`` cookie and
+    must echo it in the ``X-CSRF-Token`` header for any non-safe method. Safe
+    methods (GET/HEAD/OPTIONS) are never blocked — they only get a cookie issued.
+    """
+    cookie_token = request.cookies.get(CSRF_COOKIE)
+    if request.method not in CSRF_SAFE_METHODS:
+        header_token = request.headers.get(CSRF_HEADER, "")
+        if not (
+            cookie_token
+            and header_token
+            and secrets.compare_digest(cookie_token, header_token)
+        ):
+            resp = JSONResponse(
+                {"detail": "CSRF token missing or invalid"}, status_code=403
+            )
+            _issue_csrf_cookie(resp, cookie_token)
+            return resp
+    response = await call_next(request)
+    _issue_csrf_cookie(response, cookie_token)
+    return response
+
 
 # Web routes live in routes.py (APIRouter).
 from routes import router  # noqa: E402  (imported after app/auth are defined)

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -4,6 +4,27 @@
 
 'use strict';
 
+/* ── CSRF ───────────────────────────────────────────────────── */
+/* Echo the csrf_token cookie in the X-CSRF-Token header on every
+   state-changing request, so the server's CSRF check passes. Wraps fetch
+   once so all existing call sites are covered. */
+(function () {
+  const _origFetch = window.fetch;
+  window.fetch = function (url, opts) {
+    opts = opts || {};
+    const method = (opts.method || 'GET').toUpperCase();
+    if (method !== 'GET' && method !== 'HEAD' && method !== 'OPTIONS') {
+      const m = document.cookie.match(/(?:^|;\s*)csrf_token=([^;]+)/);
+      if (m) {
+        const headers = new Headers(opts.headers || {});
+        headers.set('X-CSRF-Token', decodeURIComponent(m[1]));
+        opts.headers = headers;
+      }
+    }
+    return _origFetch.call(this, url, opts);
+  };
+})();
+
 /* ── Theme ──────────────────────────────────────────────────── */
 function initTheme() {
   const saved = localStorage.getItem('tf-theme');

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -31,7 +31,13 @@ import routes  # noqa: E402
 def client():
     # No context manager -> lifespan startup is skipped, so no background
     # update task / outbound calls are spawned during tests.
-    return TestClient(main.app)
+    c = TestClient(main.app)
+    # Obtain a CSRF cookie and echo it on subsequent state-changing requests.
+    c.get("/")
+    token = c.cookies.get("csrf_token")
+    if token:
+        c.headers.update({"X-CSRF-Token": token})
+    return c
 
 
 # ── Read endpoints ──────────────────────────────────────────────
@@ -117,6 +123,29 @@ def test_add_and_remove_apprise_url(client, monkeypatch):
     r = client.request("DELETE", f"/api/apprise-urls/{encoded}")
     assert r.status_code == 200
     assert url not in r.json()["apprise_urls"]
+
+
+# ── CSRF protection ─────────────────────────────────────────────
+def test_csrf_blocks_state_change_without_token():
+    # Fresh client with no CSRF cookie/header -> state change rejected.
+    c = TestClient(main.app)
+    assert c.post("/api/testflight-ids/validate", json={"id": "abcd1234"}).status_code == 403
+    assert c.delete("/api/testflight-ids/anything").status_code == 403
+    assert c.post("/api/control/stop").status_code == 403
+
+
+def test_csrf_does_not_affect_get():
+    c = TestClient(main.app)
+    assert c.get("/api/health").status_code == 200
+    assert c.get("/api/testflight-ids").status_code == 200
+    assert c.get("/api/metrics").status_code == 200
+
+
+def test_csrf_allows_state_change_with_token(client):
+    # The `client` fixture already carries a valid CSRF cookie + header.
+    r = client.post("/api/testflight-ids/validate", json={"id": "!!bad!!"})
+    assert r.status_code == 200
+    assert r.json()["valid"] is False
 
 
 # ── Optional HTTP Basic auth ────────────────────────────────────


### PR DESCRIPTION
**Runbook 01 — Security Hardening, Task 4 only.** (One task; commit and stop. Left unmerged for review.)

Adds CSRF protection to **every state-changing endpoint** using the double-submit-cookie pattern, implemented as **app-level middleware** so no route handlers change and **GET endpoints are untouched**.

## How it works
- The server issues a `csrf_token` cookie (`SameSite=Strict`, JS-readable, `path=/`) on any response when the client doesn't already have one.
- Any **non-safe method** (POST/PUT/PATCH/DELETE) must echo that token in the `X-CSRF-Token` header. Missing or mismatched (`secrets.compare_digest`) → **403** before the handler runs.
- **Safe methods (GET/HEAD/OPTIONS) are never blocked** — they only get a cookie issued.

This covers all mutating routes uniformly: add/remove/validate/batch TestFlight IDs, add/remove/validate Apprise URLs, `control/stop`, `control/restart`, `config` save, `config/restore`.

## Frontend
`static/js/main.js` wraps `fetch` once to attach the header on state-changing requests, so every existing call site is covered without touching them.

## Tests
- `test_csrf_blocks_state_change_without_token` — POST/DELETE/stop without a token → 403.
- `test_csrf_does_not_affect_get` — health/ids/metrics GET → 200.
- `test_csrf_allows_state_change_with_token` — POST with a valid token succeeds.
- The shared `client` fixture now obtains + echoes the token, so the existing add/remove tests still pass.

Full suite: **42 passed**. Also verified live with curl: GET issues the cookie; POST without/with-wrong token → 403; POST with matching cookie+header → 200; GET unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)