### PR TITLE
Pin remaining dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ python-dotenv>=1.2.2,<2.0.0
 uvicorn[standard]>=0.45.0,<1.0.0
 jinja2>=3.1.0,<4.0.0
 colorama>=0.4.6,<1.0.0
-python-multipart
+python-multipart>=0.0.20,<1.0.0

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -1,4 +1,4 @@
-pytest>=9.0.3
-pytest-asyncio>=1.3.0
-pytest-mock>=3.15.1
+pytest>=9.0.3,<10.0.0
+pytest-asyncio>=1.3.0,<2.0.0
+pytest-mock>=3.15.1,<4.0.0
 httpx>=0.27,<1.0  # required by FastAPI/Starlette TestClient (tests/test_api.py)


### PR DESCRIPTION
**Runbook 01 — Security Hardening, Task 5 only.** (One task; commit and stop. Left unmerged for review.)

Pins the remaining unbounded packages so installs/builds are reproducible.

## Changes
- **`requirements.txt`** — `python-multipart` had **no version constraint at all** (and the file lacked a trailing newline) → `python-multipart>=0.0.20,<1.0.0`.
- **`tests/requirements-test.txt`** — added upper bounds to `pytest`, `pytest-asyncio`, and `pytest-mock` (they had lower bounds only).

Every requirement line now carries an upper bound (verified).

## Docker
No change needed. The image only runs `pip install -r requirements.txt` (no other unpinned `pip`/`apt` installs), so it picks up the new pins automatically; the base image is already pinned to `python:3.11-slim` and the healthcheck uses the stdlib.

## Testing
- `pip install -r requirements.txt -r tests/requirements-test.txt` resolves cleanly.
- Full suite **42 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)