### PR TITLE
Fix remaining Runbook 1 hardening gaps

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -16,7 +16,9 @@ from state import (
     add_apprise_url,
     add_testflight_id,
     app_start_time,
+    apprise_url_id,
     check_github_updates,
+    find_apprise_url_by_id,
     get_current_apprise_urls,
     get_current_id_list,
     handle_shutdown_signal,
@@ -341,31 +343,31 @@ async def batch_operations(payload: BatchIdRequest):
     return result
 
 
-@router.get("/api/apprise-urls")
-async def get_apprise_urls():
-    """Get current list of Apprise URLs with service information."""
-    urls = get_current_apprise_urls()
+def _apprise_urls_payload():
+    """Build the Apprise URL list for API responses.
 
-    # Add service information for each URL
-    urls_with_info = []
-    for url in urls:
+    Each entry exposes a stable non-secret ``id`` (used for removal) and a
+    masked ``display_url`` — never the raw, secret-bearing URL.
+    """
+    payload = []
+    for url in get_current_apprise_urls():
         service_info = get_apprise_service_icon(url)
-
-        # Mask credentials/tokens for display (raw value kept in `url` for
-        # removal operations only).
-        display_url = mask_secret(url)
-
-        urls_with_info.append(
+        payload.append(
             {
-                "url": url,  # Full URL for removal operations
-                "display_url": display_url,
+                "id": apprise_url_id(url),
+                "display_url": mask_secret(url),
                 "service_name": service_info["service_name"],
                 "icon_url": service_info["icon_url"],
                 "emoji": service_info["emoji"],
             }
         )
+    return payload
 
-    return {"apprise_urls": urls_with_info}
+
+@router.get("/api/apprise-urls")
+async def get_apprise_urls():
+    """Get current list of Apprise URLs with service information."""
+    return {"apprise_urls": _apprise_urls_payload()}
 
 
 @router.post("/api/apprise-urls/validate")
@@ -397,22 +399,21 @@ async def add_url(payload: AppriseUrlRequest):
     if not success:
         raise HTTPException(status_code=400, detail=message)
 
-    return {"message": message, "apprise_urls": get_current_apprise_urls()}
+    return {"message": message, "apprise_urls": _apprise_urls_payload()}
 
 
-@router.delete("/api/apprise-urls/{url:path}")
-async def remove_url(url: str):
-    """Remove an Apprise URL."""
-    # URL decode the path parameter since it might contain special characters
-    import urllib.parse
+@router.delete("/api/apprise-urls/{url_id}")
+async def remove_url(url_id: str):
+    """Remove an Apprise URL by its non-secret id."""
+    url = find_apprise_url_by_id(url_id)
+    if url is None:
+        raise HTTPException(status_code=404, detail="Apprise URL not found")
 
-    decoded_url = urllib.parse.unquote(url)
-
-    success, message = remove_apprise_url(decoded_url)
+    success, message = remove_apprise_url(url)
     if not success:
         raise HTTPException(status_code=404, detail=message)
 
-    return {"message": message, "apprise_urls": get_current_apprise_urls()}
+    return {"message": message, "apprise_urls": _apprise_urls_payload()}
 
 
 @router.post("/api/control/stop")
@@ -484,32 +485,43 @@ async def get_config():
 
 @router.post("/api/config")
 async def save_config(content: str = Form(...)):
-    """Save changes to the .env file."""
+    """Save changes to the .env file (validated, backed up, atomic)."""
+    import shutil
+    import tempfile
+
+    env_path = ".env"
+    backup_path = f"{env_path}.backup"
+
+    # Validate before writing; abort (without touching the file) on invalid input.
+    if not isinstance(content, str) or "\x00" in content or not content.strip():
+        raise HTTPException(status_code=400, detail="Invalid configuration content")
+
     try:
-        if not isinstance(content, str):
-            raise HTTPException(status_code=400, detail="Content must be a string")
-        
-        env_path = ".env"
-        
-        # Create backup before saving
+        # Back up the current file (if any) before replacing it.
         if os.path.exists(env_path):
-            backup_path = f"{env_path}.backup"
-            with open(env_path, "r") as f:
-                backup_content = f.read()
-            with open(backup_path, "w") as f:
-                f.write(backup_content)
+            shutil.copy2(env_path, backup_path)
             logging.info(f"Created backup at {backup_path}")
-        
-        # Write new content
-        with open(env_path, "w") as f:
-            f.write(content)
-        
+
+        # Write to a temp file in the same directory, fsync, then atomically
+        # replace the original. Content is preserved exactly.
+        env_dir = os.path.dirname(os.path.abspath(env_path)) or "."
+        fd, tmp_path = tempfile.mkstemp(prefix=".env.", suffix=".tmp", dir=env_dir)
+        try:
+            with os.fdopen(fd, "w") as tmp:
+                tmp.write(content)
+                tmp.flush()
+                os.fsync(tmp.fileno())
+            os.replace(tmp_path, env_path)
+        finally:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+
         logging.info("Configuration file updated via web interface")
-        
+
         return {
             "success": True,
             "message": "Configuration saved. Restart to apply changes.",
-            "backup_created": True
+            "backup_created": os.path.exists(backup_path),
         }
     except HTTPException:
         raise

--- a/state.py
+++ b/state.py
@@ -122,6 +122,26 @@ def get_current_apprise_urls():
         return current_apprise_urls.copy()
 
 
+def apprise_url_id(url: str) -> str:
+    """Return a stable, non-secret identifier for an Apprise URL.
+
+    Lets the API/dashboard reference a URL (e.g. for removal) without exposing
+    the secret-bearing value itself.
+    """
+    import hashlib
+
+    return hashlib.sha256(url.encode("utf-8")).hexdigest()[:16]
+
+
+def find_apprise_url_by_id(url_id: str):
+    """Return the current Apprise URL whose id matches, or None."""
+    with apprise_urls_lock:
+        for u in current_apprise_urls:
+            if apprise_url_id(u) == url_id:
+                return u
+    return None
+
+
 def update_env_file(key: str, new_values: list[str]):
     """Safely update the .env file with new values for a given key.
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -367,7 +367,7 @@ function renderUrls(urls) {
         <div class="item-sub" title="${escAttr(u.display_url)}">${escHtml(u.display_url)}</div>
       </div>
       <div class="item-actions">
-        <button class="btn btn-sm btn-danger" onclick="removeUrl('${escAttr(encodeURIComponent(u.url))}')" aria-label="Remove ${escAttr(u.service_name)} URL">Remove</button>
+        <button class="btn btn-sm btn-danger" onclick="removeUrl('${escAttr(u.id)}')" aria-label="Remove ${escAttr(u.service_name)} URL">Remove</button>
       </div>
     </div>`;
   }).join('');
@@ -416,9 +416,9 @@ async function validateAndAddUrl() {
   addBtn.disabled = false;
 }
 
-async function removeUrl(encodedUrl) {
+async function removeUrl(urlId) {
   try {
-    const res  = await fetch(`/api/apprise-urls/${encodedUrl}`, { method: 'DELETE' });
+    const res  = await fetch(`/api/apprise-urls/${urlId}`, { method: 'DELETE' });
     const data = await res.json();
     if (res.ok) {
       renderUrls(data.apprise_urls);

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,10 +9,11 @@ optional HTTP Basic auth.
 
 import asyncio
 import importlib
+import json
 import os
-import urllib.parse
 
 import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 # The app reads required config at import time, so set it before importing.
@@ -117,12 +118,76 @@ def test_add_and_remove_apprise_url(client, monkeypatch):
 
     r = client.post("/api/apprise-urls", json={"url": url})
     assert r.status_code == 200, r.text
-    assert url in r.json()["apprise_urls"]
+    items = r.json()["apprise_urls"]
+    url_id = state.apprise_url_id(url)
+    assert any(i["id"] == url_id for i in items)
+    assert url in state.current_apprise_urls  # raw value kept in config storage
 
-    encoded = urllib.parse.quote(url, safe="")
-    r = client.request("DELETE", f"/api/apprise-urls/{encoded}")
+    # Remove by the stable non-secret id.
+    r = client.request("DELETE", f"/api/apprise-urls/{url_id}")
     assert r.status_code == 200
-    assert url not in r.json()["apprise_urls"]
+    assert url not in state.current_apprise_urls
+
+
+def test_apprise_urls_response_exposes_no_raw_url(client, monkeypatch):
+    """Issue 1: the API must not return the raw secret-bearing URL."""
+    monkeypatch.setattr(state, "update_env_file", lambda *a, **k: True)
+    monkeypatch.setattr(state, "send_notification", lambda *a, **k: None)
+
+    secret = "discord://999999/TopSecretToken12345"
+    state.current_apprise_urls[:] = [secret]
+
+    body = client.get("/api/apprise-urls").json()
+    item = body["apprise_urls"][0]
+    assert "url" not in item  # no raw URL field
+    assert item["id"] == state.apprise_url_id(secret)  # stable id for removal
+    assert "TopSecretToken12345" not in item["display_url"]  # display masked
+    # The secret must not appear anywhere in the response.
+    assert "TopSecretToken12345" not in json.dumps(body)
+
+
+# ── Hardened .env save (Issue 2) ────────────────────────────────
+def test_save_config_atomic_with_backup(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    env = tmp_path / ".env"
+    env.write_text("APPRISE_URL=discord://a/b\n# old comment\n")
+
+    new_content = "APPRISE_URL=discord://c/d\nID_LIST=abc123\n# new comment\n"
+    res = asyncio.run(routes.save_config(content=new_content))
+
+    assert res["success"] is True
+    # Content preserved exactly.
+    assert env.read_text() == new_content
+    # Backup holds the previous version.
+    backup = tmp_path / ".env.backup"
+    assert backup.exists()
+    assert "discord://a/b" in backup.read_text()
+    # No leftover temp files.
+    assert not [p for p in tmp_path.iterdir() if p.name.endswith(".tmp")]
+
+
+def test_save_config_aborts_on_empty(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    env = tmp_path / ".env"
+    original = "APPRISE_URL=discord://a/b\n"
+    env.write_text(original)
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(routes.save_config(content="   "))
+    assert exc.value.status_code == 400
+    assert env.read_text() == original  # untouched
+
+
+def test_save_config_aborts_on_null_byte(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    env = tmp_path / ".env"
+    original = "APPRISE_URL=discord://a/b\n"
+    env.write_text(original)
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(routes.save_config(content="APPRISE_URL=x\x00y\n"))
+    assert exc.value.status_code == 400
+    assert env.read_text() == original
 
 
 # ── CSRF protection ─────────────────────────────────────────────


### PR DESCRIPTION
Two leftover Runbook 1 gaps, in one PR. No unrelated refactors.

## Issue 1 — `/api/apprise-urls` no longer leaks the raw URL
The response (and the add/remove responses) used to include the raw, secret-bearing `url`. Now each entry exposes:
- **`id`** — a stable, non-secret identifier (`sha256(url)[:16]`) used for removal,
- **`display_url`** — masked (unchanged),

and **no raw `url`**. Removal is keyed by the id (`DELETE /api/apprise-urls/{url_id}` → `state.find_apprise_url_by_id`). The dashboard JS deletes by id. A shared `_apprise_urls_payload()` builds the masked list for GET/add/remove so none of them return raw secrets. Raw values stay only in config storage (`.env` + in-memory list).

**Live-verified:** `GET /api/apprise-urls` → keys `[display_url, emoji, icon_url, id, service_name]` (no `url`), `display_url=discord://******n999`, secret absent from the whole response; `DELETE /{id}` → 200, list empties.

## Issue 2 — `/api/config` save is now hardened (same pattern as `update_env_file`)
- **Validate before write** — reject non-string / null-byte / empty content → 400, file untouched.
- **Backup** — copy the current file to `.env.backup` first (kept this name so `restore_config` still works).
- **Temp file + fsync + atomic replace** — write to `tempfile.mkstemp(dir=<same dir>)`, fsync, `os.replace()`; temp cleaned up on any failure.
- **Preserve content exactly** when valid.

`restore_config` and `get_config` are left unchanged (out of scope).

## Tests
- `test_apprise_urls_response_exposes_no_raw_url` — no `url` field, masked display, id present, secret absent from response.
- `test_add_and_remove_apprise_url` — updated to add + remove by id.
- `test_save_config_atomic_with_backup` — exact content preserved, `.env.backup` holds previous, no temp leftovers.
- `test_save_config_aborts_on_empty` / `test_save_config_aborts_on_null_byte` — 400 and file untouched.

Full suite: **46 passed**, pyflakes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)