### PR TITLE
Add test notification feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A Python-based monitoring tool that continuously checks Apple TestFlight beta av
 - ⚡ **High Performance** – Async HTTP requests with connection pooling and caching
 - 🔄 **Status Tracking** – Detects status changes (Open, Full, Closed) and notifies accordingly
 - 💓 **Heartbeat Notifications** – Optional periodic notifications to confirm the service is running
+- 🧪 **Test Notification** – Send a one-off test message to your configured destinations from the dashboard
 - 🎨 **Dark/Light Theme** – Responsive web dashboard with persistent theme preference
 - 📝 **Live Config Editor** – Edit your `.env` file and restart the service directly from the dashboard
 - 🔍 **Update Checker** – Optional GitHub version checks with toggle in the dashboard
@@ -205,7 +206,7 @@ Once running, access the web dashboard at `http://localhost:8080` (or your confi
 
 - **Dashboard** – Live status of all monitored betas, uptime, metrics, and service controls (start/stop/restart)
 - **TestFlight IDs** – Add or remove IDs to monitor without restarting
-- **Apprise URLs** – Add or remove notification endpoints on the fly
+- **Apprise URLs** – Add or remove notification endpoints on the fly, and send a test notification to confirm they work
 - **Settings** – Toggle options (update checker, always-notify), change the default theme, and edit the `.env` file directly with the built-in editor
 - **Logs** – Filterable live log viewer with level and line-count controls
 
@@ -230,6 +231,7 @@ Interactive OpenAPI docs are available at `/docs`.
 | `/api/config` | GET / POST | Read or write the `.env` configuration file |
 | `/api/control/stop` | POST | Stop the service |
 | `/api/control/restart` | POST | Restart the service (re-executes in place) |
+| `/api/test-notification` | POST | Send a test notification to the configured Apprise destinations |
 
 ## Dependencies
 

--- a/routes.py
+++ b/routes.py
@@ -47,7 +47,7 @@ from utils.formatting import (
     app_name_cache,
     app_icon_cache,
 )
-from utils.notifications import send_notification_async
+from utils.notifications import send_notification_async, send_test_notification
 from utils.masking import mask_secret
 from utils.service_icons import get_apprise_service_icon
 from utils.web_logging import get_recent_logs, log_entries, log_entries_lock
@@ -414,6 +414,39 @@ async def remove_url(url_id: str):
         raise HTTPException(status_code=404, detail=message)
 
     return {"message": message, "apprise_urls": _apprise_urls_payload()}
+
+
+@router.post("/api/test-notification")
+async def test_notification():
+    """Send a one-off test notification to the configured Apprise destinations.
+
+    Does not perform any TestFlight checks or modify runtime state.
+    """
+    logging.info("Test notification requested")
+    urls = get_current_apprise_urls()
+    if not urls:
+        logging.warning("Test notification failed: no destinations configured")
+        raise HTTPException(
+            status_code=400, detail="No notification destinations are configured"
+        )
+
+    sent, failed = await send_test_notification(urls)
+    total = sent + failed
+
+    if sent > 0:
+        logging.info("Test notification succeeded (%d/%d destinations)", sent, total)
+        return {
+            "success": True,
+            "sent": sent,
+            "failed": failed,
+            "total": total,
+            "message": f"Test notification sent to {sent} of {total} destination(s).",
+        }
+
+    logging.error("Test notification failed: all %d destination(s) failed", total)
+    raise HTTPException(
+        status_code=502, detail="All notification attempts failed"
+    )
 
 
 @router.post("/api/control/stop")

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -432,6 +432,28 @@ async function removeUrl(urlId) {
   }
 }
 
+async function sendTestNotification() {
+  const btn = document.getElementById('test-notify-btn');
+  if (!btn || btn.disabled) return;        // prevent duplicate clicks
+  const original = btn.textContent;
+  btn.disabled = true;
+  btn.textContent = 'Sending…';            // loading indicator
+  try {
+    const res  = await fetch('/api/test-notification', { method: 'POST' });
+    const data = await res.json();
+    if (res.ok && data.success) {
+      showToast(data.message || 'Test notification sent.', 'success', 'Sent');
+    } else {
+      showToast(data.detail || 'Failed to send test notification.', 'error');
+    }
+  } catch (e) {
+    showToast(`Error: ${e.message}`, 'error');
+  } finally {
+    btn.disabled = false;
+    btn.textContent = original;
+  }
+}
+
 /* ── Settings / Config ──────────────────────────────────────── */
 async function loadConfig() {
   const editor    = document.getElementById('config-editor');

--- a/templates/index.html
+++ b/templates/index.html
@@ -298,6 +298,10 @@
               <button class="btn btn-primary" id="add-url-btn" onclick="validateAndAddUrl()">Validate &amp; Add</button>
             </div>
             <div id="add-url-status" class="status-msg" role="status" aria-live="polite"></div>
+            <div class="settings-save-bar">
+              <button class="btn btn-secondary" id="test-notify-btn" onclick="sendTestNotification()">Send Test Notification</button>
+              <span class="text-muted text-sm">Sends a test message to all configured destinations.</span>
+            </div>
           </div>
         </div>
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -146,6 +146,55 @@ def test_apprise_urls_response_exposes_no_raw_url(client, monkeypatch):
     assert "TopSecretToken12345" not in json.dumps(body)
 
 
+# ── Test notification (Runbook 2) ───────────────────────────────
+def test_test_notification_success(client, monkeypatch):
+    async def fake_send(urls):
+        return (1, 0)  # one delivered
+
+    monkeypatch.setattr(routes, "send_test_notification", fake_send)
+    saved = list(state.current_apprise_urls)
+    try:
+        state.current_apprise_urls[:] = ["json://localhost/"]
+        r = client.post("/api/test-notification")
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["success"] is True
+        assert body["sent"] == 1
+    finally:
+        state.current_apprise_urls[:] = saved
+
+
+def test_test_notification_all_fail(client, monkeypatch):
+    async def fake_send(urls):
+        return (0, 2)  # every destination failed
+
+    monkeypatch.setattr(routes, "send_test_notification", fake_send)
+    saved = list(state.current_apprise_urls)
+    try:
+        state.current_apprise_urls[:] = ["json://a/", "json://b/"]
+        r = client.post("/api/test-notification")
+        assert r.status_code == 502
+        assert "fail" in r.json()["detail"].lower()
+    finally:
+        state.current_apprise_urls[:] = saved
+
+
+def test_test_notification_no_destinations(client):
+    saved = list(state.current_apprise_urls)
+    try:
+        state.current_apprise_urls[:] = []
+        r = client.post("/api/test-notification")
+        assert r.status_code == 400
+    finally:
+        state.current_apprise_urls[:] = saved
+
+
+def test_test_notification_requires_csrf():
+    # State-changing POST with no CSRF token is rejected (authorization).
+    c = TestClient(main.app)
+    assert c.post("/api/test-notification").status_code == 403
+
+
 # ── Hardened .env save (Issue 2) ────────────────────────────────
 def test_save_config_atomic_with_backup(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)

--- a/utils/notifications.py
+++ b/utils/notifications.py
@@ -1,6 +1,43 @@
 import logging
 import asyncio
 
+TEST_NOTIFICATION_TITLE = "TestFlight Apprise Notifier"
+TEST_NOTIFICATION_BODY = (
+    "✅ Test notification from TestFlight Apprise Notifier. "
+    "If you received this, your notifications are working."
+)
+
+
+def _send_test_sync(urls):
+    """Send a test notification to each Apprise URL independently.
+
+    Returns a (sent, failed) count tuple. Sends to each destination on its own
+    so a partial outcome ("at least one sent") can be reported. Never logs or
+    returns the URLs/secrets themselves.
+    """
+    import apprise
+
+    sent = 0
+    failed = 0
+    for url in urls:
+        try:
+            target = apprise.Apprise()
+            if target.add(url) and target.notify(
+                body=TEST_NOTIFICATION_BODY, title=TEST_NOTIFICATION_TITLE
+            ):
+                sent += 1
+            else:
+                failed += 1
+        except Exception:
+            failed += 1
+    return sent, failed
+
+
+async def send_test_notification(urls):
+    """Async wrapper: send a one-off test notification to each configured URL."""
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(None, _send_test_sync, list(urls))
+
 
 def send_notification(message: str, apobj, icon_url: str = ""):
     """Send notification using Apprise with error handling.


### PR DESCRIPTION
**Runbook 2 — Task 6.** Implements a Test Notification feature for the dashboard.

## Backend
New `POST /api/test-notification` (in `routes.py`): sends a one-off test message to the **currently configured** Apprise destinations. No TestFlight checks; no runtime-state changes (reads a copy of the URL list). New `send_test_notification` helper in `utils/notifications.py` sends to each destination independently (reusing Apprise) so partial outcomes are reported:

- ≥1 delivered → `200` `{success, sent, failed, total, message}`
- 0 destinations configured → `400`
- all attempts failed → `502`

Logs **request / success / failure with counts only** — never URLs, tokens, or secrets. Protected by the same auth + CSRF as other state-changing endpoints.

## Frontend
A **"Send Test Notification"** button in the Notifications section: shows a `Sending…` loading state, disables itself to prevent duplicate clicks, and toasts success or a clear error.

## Tests (`tests/test_api.py`)
- `test_test_notification_success` — ≥1 sent → 200, `success:true`.
- `test_test_notification_all_fail` — all fail → 502.
- `test_test_notification_no_destinations` — none configured → 400.
- `test_test_notification_requires_csrf` — POST without CSRF token → 403 (authorization).

Full suite: **50 passed**, pyflakes clean.

## Manual verification
Ran the app against a local receiver: success path → `{"success":true,"sent":1,...}` with log `Test notification succeeded (1/1 destinations)`; no-receiver → `502` with log `failed: all 1 destination(s) failed`; no CSRF → `403`; confirmed the destination/secret never appears in logs. Browser-drove the button: mid-flight `disabled` + `Sending…`, a duplicate click during processing was ignored (one toast), button re-enabled afterward, success toast shown.

## Constraints
No unrelated refactors; existing notification behavior (`send_notification`/`send_notification_async`) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)