### PR TITLE
Persist runtime state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ build/
 *.tmp
 *.bak
 *.swp
+
+# Runtime state persistence
+data/state.json
+data/.state.*.tmp

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A Python-based monitoring tool that continuously checks Apple TestFlight beta av
 - 🐳 **Docker Support** – Easy deployment with Docker and Docker Compose
 - ⚡ **High Performance** – Async HTTP requests with connection pooling and caching
 - 🔄 **Status Tracking** – Detects status changes (Open, Full, Closed) and notifies accordingly
+- 💾 **State Persistence** – Saves runtime state to disk and resumes after a restart without re-sending duplicate notifications
 - 💓 **Heartbeat Notifications** – Optional periodic notifications to confirm the service is running
 - 🧪 **Test Notification** – Send a one-off test message to your configured destinations from the dashboard
 - 🎨 **Dark/Light Theme** – Responsive web dashboard with persistent theme preference
@@ -112,6 +113,7 @@ All configuration is done through environment variables in the `.env` file. You 
 | `GITHUB_REPO` | `klept0/TestFlight_Apprise_Notifier` | GitHub repo to check for updates |
 | `GITHUB_BRANCH` | `main` | Branch to compare against for update checks |
 | `UI_THEME` | `dark` | Default web dashboard theme (`dark` or `light`) |
+| `STATE_FILE` | `data/state.json` | Where runtime state is persisted (per-ID status, timestamps, failure counts, cached app name/icon) so monitoring resumes cleanly after a restart |
 | `FASTAPI_HOST` | `127.0.0.1` | Web dashboard bind address (set `0.0.0.0` to expose it) |
 | `FASTAPI_PORT` | random `8000–9000` | Web dashboard port (set explicitly to keep it stable) |
 | `WEB_USERNAME` | _(unset)_ | Username for optional HTTP Basic auth on the dashboard/API |

--- a/main.py
+++ b/main.py
@@ -7,6 +7,8 @@ import logging
 import signal
 import random
 import secrets
+import time
+import persistence
 from contextlib import asynccontextmanager
 from fastapi import FastAPI, HTTPException, Request, Depends
 from fastapi.responses import JSONResponse
@@ -32,6 +34,8 @@ from utils.formatting import (
     format_notification_link,
     get_app_icon,
     get_app_name,
+    app_name_cache,
+    app_icon_cache,
 )
 from utils.colors import print_green
 from utils.testflight import (
@@ -98,6 +102,80 @@ _status_lock = threading.Lock()
 # Track whether an OPEN notification has been sent per TestFlight ID
 _open_notified: Dict[str, bool] = {}  # tf_id -> notification sent?
 _open_notified_lock = threading.Lock()
+
+# Additional per-ID runtime state (guarded by _status_lock).
+_last_notification_ts: Dict[str, float] = {}  # tf_id -> epoch seconds
+_last_success_ts: Dict[str, float] = {}  # tf_id -> epoch seconds
+_failure_count: Dict[str, int] = {}  # tf_id -> consecutive failures
+
+
+def snapshot_runtime_state() -> dict:
+    """Build a JSON-serializable snapshot of the monitor's runtime state."""
+    with _status_lock:
+        prev = dict(_previous_status)
+        notif = dict(_last_notification_ts)
+        succ = dict(_last_success_ts)
+        fail = dict(_failure_count)
+    with _open_notified_lock:
+        opened = dict(_open_notified)
+
+    apps = {}
+    for tf_id in set(prev) | set(notif) | set(succ) | set(fail) | set(opened):
+        cache_key = f"{TESTFLIGHT_URL}:{tf_id}"
+        status = prev.get(tf_id)
+        apps[tf_id] = {
+            "status": status.value if status else None,
+            "notified_open": opened.get(tf_id, False),
+            "last_notification_ts": notif.get(tf_id),
+            "last_success_ts": succ.get(tf_id),
+            "failure_count": fail.get(tf_id, 0),
+            "app_name": app_name_cache.get(cache_key),
+            "icon_url": app_icon_cache.get(cache_key),
+        }
+    return {"version": persistence.STATE_VERSION, "apps": apps}
+
+
+def restore_runtime_state(snapshot: dict) -> None:
+    """Repopulate live monitor state from a snapshot, skipping bad entries."""
+    apps = (snapshot or {}).get("apps", {})
+    if not isinstance(apps, dict):
+        return
+    restored = 0
+    for tf_id, rec in apps.items():
+        if not isinstance(rec, dict):
+            continue
+        try:
+            with _status_lock:
+                status_val = rec.get("status")
+                if status_val:
+                    try:
+                        _previous_status[tf_id] = TestFlightStatus(status_val)
+                    except ValueError:
+                        pass
+                if rec.get("last_notification_ts") is not None:
+                    _last_notification_ts[tf_id] = float(rec["last_notification_ts"])
+                if rec.get("last_success_ts") is not None:
+                    _last_success_ts[tf_id] = float(rec["last_success_ts"])
+                _failure_count[tf_id] = int(rec.get("failure_count", 0) or 0)
+            with _open_notified_lock:
+                _open_notified[tf_id] = bool(rec.get("notified_open", False))
+
+            cache_key = f"{TESTFLIGHT_URL}:{tf_id}"
+            if rec.get("app_name"):
+                app_name_cache.put(cache_key, rec["app_name"])
+            if rec.get("icon_url"):
+                app_icon_cache.put(cache_key, rec["icon_url"])
+            restored += 1
+        except Exception as e:  # noqa: BLE001 - one bad entry must not abort restore
+            logging.warning("Skipping corrupt state entry for %s: %s", tf_id, e)
+
+    if restored:
+        logging.info("Restored runtime state for %d TestFlight ID(s)", restored)
+
+
+def persist_runtime_state() -> None:
+    """Persist the current runtime state snapshot to disk (best effort)."""
+    persistence.save_state(snapshot_runtime_state())
 
 
 # Configure colored console logging (see utils/web_logging.py).
@@ -278,6 +356,8 @@ async def fetch_testflight_status(session, tf_id):
 
         # Handle errors
         if result["status"] == TestFlightStatus.ERROR:
+            with _status_lock:
+                _failure_count[tf_id] = _failure_count.get(tf_id, 0) + 1
             logging.warning(
                 "%s - %s - Error: %s",
                 result.get("status_text", "Unknown"),
@@ -296,6 +376,8 @@ async def fetch_testflight_status(session, tf_id):
         with _status_lock:
             previous_status = _previous_status.get(tf_id)
             _previous_status[tf_id] = current_status
+            _last_success_ts[tf_id] = time.time()
+            _failure_count[tf_id] = 0
 
         # Determine if we should notify
         should_notify = False
@@ -358,9 +440,13 @@ async def fetch_testflight_status(session, tf_id):
                 base_url = "https://developer.apple.com/assets/elements/icons"
                 icon_url = f"{base_url}/testflight/testflight-64x64_2x.png"
             await send_notification_async(notify_msg, apobj, icon_url)
+            with _status_lock:
+                _last_notification_ts[tf_id] = time.time()
             logging.info(f"Notification sent for {app_name}")
 
     except Exception as e:
+        with _status_lock:
+            _failure_count[tf_id] = _failure_count.get(tf_id, 0) + 1
         _metrics.record_check(TestFlightStatus.ERROR, success=False)
         logging.error(f"Unexpected error fetching {tf_id}: {e}")
 
@@ -411,6 +497,8 @@ async def start_watching():
         await asyncio.sleep(2)
         while not shutdown_event.is_set():
             await watch()
+            # Persist after each cycle so state survives an unclean exit too.
+            persist_runtime_state()
             await asyncio.sleep(SLEEP_TIME / 1000)  # Convert ms to seconds
     except asyncio.CancelledError:
         logging.info("Watching task cancelled during shutdown")
@@ -491,6 +579,11 @@ async def async_main():
         # `docker stop`) triggers a graceful shutdown.
         install_signal_handlers()
 
+        # Restore persisted runtime state before monitoring starts so we resume
+        # without re-sending duplicate notifications, then (re)create the file.
+        restore_runtime_state(persistence.load_state())
+        persist_runtime_state()
+
         # Create tasks
         watching_task = asyncio.create_task(start_watching())
         heartbeat_task = asyncio.create_task(heartbeat())
@@ -534,6 +627,8 @@ async def async_main():
     except Exception as e:
         logging.error(f"Error in async main: {e}")
     finally:
+        # Persist runtime state on shutdown so the next start resumes cleanly.
+        persist_runtime_state()
         # Clean up HTTP session
         await cleanup_http_session()
         logging.info("HTTP session cleaned up.")

--- a/persistence.py
+++ b/persistence.py
@@ -1,0 +1,65 @@
+"""
+Runtime state persistence.
+
+Stores per-TestFlight-ID monitor state (last known status, last notification /
+last successful check timestamps, failure count) plus the cached app name and
+icon URL to a JSON file, so the app can resume cleanly after a restart without
+re-sending duplicate notifications.
+
+Reads tolerate a missing or corrupt file (returning an empty state so startup
+can proceed). Writes are atomic (temp file + fsync + os.replace).
+"""
+
+import json
+import logging
+import os
+import tempfile
+
+# Location of the state file (overridable for tests / custom deployments).
+STATE_FILE = os.getenv("STATE_FILE", "data/state.json")
+STATE_VERSION = 1
+
+
+def load_state() -> dict:
+    """Load persisted runtime state.
+
+    Returns an empty dict if the file is missing, unreadable, or corrupt — a
+    bad state file must never prevent startup.
+    """
+    try:
+        if not os.path.exists(STATE_FILE):
+            return {}
+        with open(STATE_FILE, "r") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            logging.warning("Runtime state file is not an object; ignoring it")
+            return {}
+        return data
+    except (json.JSONDecodeError, ValueError, OSError) as e:
+        logging.warning("Could not load runtime state (%s); starting fresh", e)
+        return {}
+
+
+def save_state(state: dict) -> bool:
+    """Atomically persist runtime state to disk. Returns True on success.
+
+    Failures are logged but never raised, so a write problem can't crash the
+    monitor loop or shutdown.
+    """
+    try:
+        directory = os.path.dirname(os.path.abspath(STATE_FILE)) or "."
+        os.makedirs(directory, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(prefix=".state.", suffix=".tmp", dir=directory)
+        try:
+            with os.fdopen(fd, "w") as tmp:
+                json.dump(state, tmp, indent=2)
+                tmp.flush()
+                os.fsync(tmp.fileno())
+            os.replace(tmp_path, STATE_FILE)
+        finally:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+        return True
+    except OSError as e:
+        logging.error("Failed to persist runtime state: %s", e)
+        return False

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,0 +1,139 @@
+"""Tests for runtime state persistence (persistence.py + main integration)."""
+
+import asyncio
+import os
+
+os.environ.setdefault("APPRISE_URL", "json://localhost/")
+
+import persistence  # noqa: E402
+import main  # noqa: E402
+from utils.testflight import TestFlightStatus  # noqa: E402
+
+
+def _clear_live_state():
+    main._previous_status.clear()
+    main._open_notified.clear()
+    main._failure_count.clear()
+    main._last_success_ts.clear()
+    main._last_notification_ts.clear()
+    main.app_name_cache.cache.clear()
+    main.app_icon_cache.cache.clear()
+
+
+# ── persistence.py: file handling ───────────────────────────────
+def test_initial_state_creation(tmp_path, monkeypatch):
+    state_file = tmp_path / "state.json"
+    monkeypatch.setattr(persistence, "STATE_FILE", str(state_file))
+    assert not state_file.exists()
+    assert persistence.save_state({"version": 1, "apps": {}}) is True
+    assert state_file.exists()
+    # A missing file loads as empty (no error) so startup can proceed.
+    state_file.unlink()
+    assert persistence.load_state() == {}
+
+
+def test_state_persistence_roundtrip(tmp_path, monkeypatch):
+    state_file = tmp_path / "state.json"
+    monkeypatch.setattr(persistence, "STATE_FILE", str(state_file))
+    data = {"version": 1, "apps": {"abc12345": {"status": "open", "failure_count": 2}}}
+    assert persistence.save_state(data) is True
+    assert persistence.load_state() == data
+    # Atomic write leaves no temp files behind.
+    assert not [p for p in tmp_path.iterdir() if p.name.endswith(".tmp")]
+
+
+def test_corrupt_state_recovery(tmp_path, monkeypatch):
+    state_file = tmp_path / "state.json"
+    state_file.write_text("{ not valid json :::")
+    monkeypatch.setattr(persistence, "STATE_FILE", str(state_file))
+    # Must not raise; returns empty so the app can still start.
+    assert persistence.load_state() == {}
+    # A non-object payload is also ignored.
+    state_file.write_text("[1, 2, 3]")
+    assert persistence.load_state() == {}
+
+
+# ── main.py: snapshot / restore ─────────────────────────────────
+def test_snapshot_and_restore_roundtrip():
+    _clear_live_state()
+    main._previous_status["t1abcdef"] = TestFlightStatus.FULL
+    main._open_notified["t1abcdef"] = True
+    main._failure_count["t1abcdef"] = 4
+    main._last_success_ts["t1abcdef"] = 222.0
+    main._last_notification_ts["t1abcdef"] = 111.0
+    main.app_name_cache.put(f"{main.TESTFLIGHT_URL}:t1abcdef", "My App")
+    main.app_icon_cache.put(f"{main.TESTFLIGHT_URL}:t1abcdef", "http://i/x.png")
+
+    snap = main.snapshot_runtime_state()
+    rec = snap["apps"]["t1abcdef"]
+    assert rec["status"] == "full"
+    assert rec["notified_open"] is True
+    assert rec["failure_count"] == 4
+    assert rec["app_name"] == "My App"
+    assert rec["icon_url"] == "http://i/x.png"
+
+    _clear_live_state()
+    main.restore_runtime_state(snap)
+    assert main._previous_status["t1abcdef"] == TestFlightStatus.FULL
+    assert main._open_notified["t1abcdef"] is True
+    assert main._failure_count["t1abcdef"] == 4
+    assert main._last_notification_ts["t1abcdef"] == 111.0
+    key = f"{main.TESTFLIGHT_URL}:t1abcdef"
+    assert main.app_name_cache.get(key) == "My App"
+    assert main.app_icon_cache.get(key) == "http://i/x.png"
+
+
+def test_restore_skips_corrupt_entries():
+    _clear_live_state()
+    snap = {
+        "apps": {
+            "good1234": {"status": "open", "notified_open": True},
+            "bad12345": {"status": "not-a-real-status", "failure_count": "oops"},
+            "weird999": "not-a-dict",
+        }
+    }
+    # Must not raise; the good entry is restored.
+    main.restore_runtime_state(snap)
+    assert main._open_notified.get("good1234") is True
+
+
+# ── Duplicate-notification prevention after restart ─────────────
+def _patch_fetch_deps(monkeypatch, sent, status=TestFlightStatus.OPEN):
+    async def fake_check(session, url):
+        return {"status": status, "status_text": status.value, "app_name": "App"}
+
+    async def fake_name(base, tf):
+        return "App"
+
+    async def fake_icon(base, tf):
+        return "http://i/x.png"
+
+    async def fake_link(base, tf):
+        return "Beta is OPEN"
+
+    async def fake_send(*a, **k):
+        sent.append(a)
+
+    monkeypatch.setattr(main, "check_testflight_status", fake_check)
+    monkeypatch.setattr(main, "get_app_name", fake_name)
+    monkeypatch.setattr(main, "get_app_icon", fake_icon)
+    monkeypatch.setattr(main, "format_notification_link", fake_link)
+    monkeypatch.setattr(main, "send_notification_async", fake_send)
+    monkeypatch.setattr(main, "ALWAYS_NOTIFY_OPEN", False)
+
+
+def test_no_duplicate_notification_after_restart(monkeypatch):
+    _clear_live_state()
+    # Simulate restored state: this ID was already notified as OPEN.
+    main.restore_runtime_state(
+        {"apps": {"dup12345": {"status": "open", "notified_open": True}}}
+    )
+
+    sent = []
+    _patch_fetch_deps(monkeypatch, sent)
+    asyncio.run(main.fetch_testflight_status(session=None, tf_id="dup12345"))
+    assert sent == []  # no duplicate notification after restart
+
+    # A fresh ID (never notified) still notifies on its first OPEN.
+    asyncio.run(main.fetch_testflight_status(session=None, tf_id="fresh999"))
+    assert len(sent) == 1


### PR DESCRIPTION
**Runbook 2 — Task 7.** Persists runtime state so the app resumes cleanly after a restart without re-sending duplicate notifications.

## What is persisted (per TestFlight ID)
Last known status · last notification timestamp · last successful check timestamp · failure count · cached app name · cached icon URL.

## Backend
- **`persistence.py`** — atomic JSON `load_state()` / `save_state()` (temp file + `fsync` + `os.replace`). A **missing or corrupt** file returns empty state and never blocks startup; write failures are logged, not raised. State file is `data/state.json` (override with `STATE_FILE`).
- **`main.py`** — now tracks the three new per-ID fields (last-success ts, last-notification ts, consecutive failure count) alongside the existing status / open-notified state, and reads the cached app name + icon from the existing LRU caches. `snapshot_runtime_state()` / `restore_runtime_state()` serialize all six fields (status as its enum value; corrupt entries skipped).
- **Startup** restores state *before* monitoring begins, then recreates the file if missing. **Each watch cycle** persists (survives an unclean exit), and state is persisted again **on shutdown**.

## Reliability
Atomic writes; corruption tolerated (load → `{}`, logged); per-entry restore guarded so one bad record can't abort restore; all I/O errors logged without terminating.

## Constraints honored
Notification decision logic is unchanged — only new tracking/persistence was added; no unrelated refactors.

## Tests (`tests/test_persistence.py`)
Initial state creation · persistence round-trip · restoration · corrupt-state recovery (invalid JSON + non-object) · **duplicate-notification prevention after restart** (restored `notified_open` → no re-notify on next OPEN; a fresh ID still notifies). Full suite: **56 passed**, pyflakes clean.

## Manual verification
Ran the app three times against a temp `.env`: run 1 created `data/state.json` (per-ID record with an incrementing failure count); run 2 logged `Restored runtime state for 1 TestFlight ID(s)`; run 3 with a deliberately corrupted state file still started normally and rewrote a valid file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)