### PR TITLE
Improve retry scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ All configuration is done through environment variables in the `.env` file. You 
 |----------|---------|-------------|
 | `INTERVAL_CHECK` | `10000` | Check interval in milliseconds |
 | `HEARTBEAT_INTERVAL` | `6` | Hours between heartbeat notifications (0 to disable) |
+| `RETRY_BACKOFF_BASE_SECONDS` | `30` | Initial per-ID cooldown after a failed check; grows exponentially per consecutive failure |
+| `RETRY_BACKOFF_MAX_SECONDS` | `3600` | Maximum per-ID retry cooldown (cap for the exponential backoff) |
 | `ALWAYS_NOTIFY_OPEN` | `false` | Send notification on every poll when status is OPEN |
 | `ENABLE_UPDATE_CHECKER` | `true` | Check GitHub for new version releases |
 | `GITHUB_CHECK_INTERVAL_HOURS` | `24` | How often to check for updates (hours) |

--- a/config.py
+++ b/config.py
@@ -111,3 +111,8 @@ APPRISE_URLS = [
 HEARTBEAT_INTERVAL = (
     int(os.getenv("HEARTBEAT_INTERVAL", "6")) * 60 * 60
 )  # Convert hours to seconds
+
+# Per-ID retry backoff (seconds). After a failed check, an ID is skipped until
+# its cooldown elapses; the delay grows exponentially up to the cap.
+RETRY_BACKOFF_BASE = float(os.getenv("RETRY_BACKOFF_BASE_SECONDS", "30"))
+RETRY_BACKOFF_MAX = float(os.getenv("RETRY_BACKOFF_MAX_SECONDS", "3600"))

--- a/main.py
+++ b/main.py
@@ -24,6 +24,8 @@ from config import (
     GITHUB_CHECK_INTERVAL,
     HEARTBEAT_INTERVAL,
     ID_LIST,
+    RETRY_BACKOFF_BASE,
+    RETRY_BACKOFF_MAX,
     SLEEP_TIME,
     TESTFLIGHT_URL,
 )
@@ -108,6 +110,51 @@ _last_notification_ts: Dict[str, float] = {}  # tf_id -> epoch seconds
 _last_success_ts: Dict[str, float] = {}  # tf_id -> epoch seconds
 _failure_count: Dict[str, int] = {}  # tf_id -> consecutive failures
 
+# Per-ID retry/backoff scheduling (guarded by _status_lock).
+_last_failure_ts: Dict[str, float] = {}  # tf_id -> epoch seconds
+_next_check_ts: Dict[str, float] = {}  # tf_id -> earliest epoch seconds to retry
+_backoff_delay: Dict[str, float] = {}  # tf_id -> current backoff delay (seconds)
+
+
+def _record_failure(tf_id: str) -> float:
+    """Record a failed check and schedule the next eligible retry.
+
+    Increments the consecutive failure count and grows the backoff delay
+    exponentially (with jitter) up to RETRY_BACKOFF_MAX. Returns the delay.
+    """
+    now = time.time()
+    with _status_lock:
+        count = _failure_count.get(tf_id, 0) + 1
+        _failure_count[tf_id] = count
+        _last_failure_ts[tf_id] = now
+        delay = min(RETRY_BACKOFF_BASE * (2 ** (count - 1)), RETRY_BACKOFF_MAX)
+        delay += random.uniform(0, delay * 0.1)  # jitter to avoid thundering herd
+        _backoff_delay[tf_id] = delay
+        _next_check_ts[tf_id] = now + delay
+    return delay
+
+
+def _record_success(tf_id: str, current_status):
+    """Record a successful check, clearing failure/backoff state.
+
+    Resets the failure count and backoff delay and clears the next-eligible
+    retry time. Returns the previous known status (for change detection).
+    """
+    with _status_lock:
+        previous = _previous_status.get(tf_id)
+        _previous_status[tf_id] = current_status
+        _last_success_ts[tf_id] = time.time()
+        _failure_count[tf_id] = 0
+        _backoff_delay[tf_id] = 0.0
+        _next_check_ts.pop(tf_id, None)
+    return previous
+
+
+def _is_in_cooldown(tf_id: str, now: float) -> bool:
+    """Return True if the ID is still within its retry cooldown window."""
+    with _status_lock:
+        return _next_check_ts.get(tf_id, 0.0) > now
+
 
 def snapshot_runtime_state() -> dict:
     """Build a JSON-serializable snapshot of the monitor's runtime state."""
@@ -116,11 +163,18 @@ def snapshot_runtime_state() -> dict:
         notif = dict(_last_notification_ts)
         succ = dict(_last_success_ts)
         fail = dict(_failure_count)
+        last_fail = dict(_last_failure_ts)
+        next_check = dict(_next_check_ts)
+        backoff = dict(_backoff_delay)
     with _open_notified_lock:
         opened = dict(_open_notified)
 
     apps = {}
-    for tf_id in set(prev) | set(notif) | set(succ) | set(fail) | set(opened):
+    all_ids = (
+        set(prev) | set(notif) | set(succ) | set(fail) | set(opened)
+        | set(last_fail) | set(next_check) | set(backoff)
+    )
+    for tf_id in all_ids:
         cache_key = f"{TESTFLIGHT_URL}:{tf_id}"
         status = prev.get(tf_id)
         apps[tf_id] = {
@@ -129,6 +183,9 @@ def snapshot_runtime_state() -> dict:
             "last_notification_ts": notif.get(tf_id),
             "last_success_ts": succ.get(tf_id),
             "failure_count": fail.get(tf_id, 0),
+            "last_failure_ts": last_fail.get(tf_id),
+            "next_check_ts": next_check.get(tf_id),
+            "backoff_delay": backoff.get(tf_id, 0.0),
             "app_name": app_name_cache.get(cache_key),
             "icon_url": app_icon_cache.get(cache_key),
         }
@@ -157,6 +214,11 @@ def restore_runtime_state(snapshot: dict) -> None:
                 if rec.get("last_success_ts") is not None:
                     _last_success_ts[tf_id] = float(rec["last_success_ts"])
                 _failure_count[tf_id] = int(rec.get("failure_count", 0) or 0)
+                if rec.get("last_failure_ts") is not None:
+                    _last_failure_ts[tf_id] = float(rec["last_failure_ts"])
+                if rec.get("next_check_ts") is not None:
+                    _next_check_ts[tf_id] = float(rec["next_check_ts"])
+                _backoff_delay[tf_id] = float(rec.get("backoff_delay", 0.0) or 0.0)
             with _open_notified_lock:
                 _open_notified[tf_id] = bool(rec.get("notified_open", False))
 
@@ -356,13 +418,13 @@ async def fetch_testflight_status(session, tf_id):
 
         # Handle errors
         if result["status"] == TestFlightStatus.ERROR:
-            with _status_lock:
-                _failure_count[tf_id] = _failure_count.get(tf_id, 0) + 1
+            delay = _record_failure(tf_id)
             logging.warning(
-                "%s - %s - Error: %s",
+                "%s - %s - Error: %s (retry in ~%ds)",
                 result.get("status_text", "Unknown"),
                 tf_id,
                 result.get("error", "Unknown error"),
+                int(delay),
             )
             return
 
@@ -371,13 +433,9 @@ async def fetch_testflight_status(session, tf_id):
         if not app_name:
             app_name = await get_app_name(TESTFLIGHT_URL, tf_id)
 
-        # Get current and previous status
+        # Get current and previous status (a successful check clears backoff)
         current_status = result["status"]
-        with _status_lock:
-            previous_status = _previous_status.get(tf_id)
-            _previous_status[tf_id] = current_status
-            _last_success_ts[tf_id] = time.time()
-            _failure_count[tf_id] = 0
+        previous_status = _record_success(tf_id, current_status)
 
         # Determine if we should notify
         should_notify = False
@@ -445,18 +503,24 @@ async def fetch_testflight_status(session, tf_id):
             logging.info(f"Notification sent for {app_name}")
 
     except Exception as e:
-        with _status_lock:
-            _failure_count[tf_id] = _failure_count.get(tf_id, 0) + 1
+        _record_failure(tf_id)
         _metrics.record_check(TestFlightStatus.ERROR, success=False)
         logging.error(f"Unexpected error fetching {tf_id}: {e}")
 
 
 async def watch():
-    """Check all TestFlight links."""
+    """Check all TestFlight links that are not in retry cooldown."""
     try:
         current_ids = get_current_id_list()
+        now = time.time()
+        # Skip only the IDs still in backoff; the rest are checked normally so
+        # one broken ID can't delay or starve the others.
+        eligible = [tf for tf in current_ids if not _is_in_cooldown(tf, now)]
+        skipped = len(current_ids) - len(eligible)
+        if skipped:
+            logging.debug("Skipping %d TestFlight ID(s) in retry cooldown", skipped)
         session = await get_http_session()
-        tasks = [fetch_testflight_status(session, tf_id) for tf_id in current_ids]
+        tasks = [fetch_testflight_status(session, tf_id) for tf_id in eligible]
         await asyncio.gather(*tasks, return_exceptions=True)
     except asyncio.CancelledError:
         logging.debug("Watch cycle cancelled during shutdown")

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,102 @@
+"""Tests for per-ID retry/backoff scheduling (Runbook 2 — Task 8)."""
+
+import asyncio
+import os
+import time
+
+os.environ.setdefault("APPRISE_URL", "json://localhost/")
+
+import main  # noqa: E402
+from utils.testflight import TestFlightStatus  # noqa: E402
+
+
+def _clear():
+    for d in (
+        main._previous_status,
+        main._open_notified,
+        main._failure_count,
+        main._last_success_ts,
+        main._last_notification_ts,
+        main._last_failure_ts,
+        main._next_check_ts,
+        main._backoff_delay,
+    ):
+        d.clear()
+
+
+def test_failure_increases_backoff():
+    _clear()
+    d1 = main._record_failure("idfail01")
+    assert main._failure_count["idfail01"] == 1
+    assert d1 >= main.RETRY_BACKOFF_BASE
+    assert main._next_check_ts["idfail01"] > time.time()
+    assert main._last_failure_ts["idfail01"] > 0
+
+    d2 = main._record_failure("idfail01")
+    assert main._failure_count["idfail01"] == 2
+    assert d2 > d1  # exponential growth
+
+
+def test_backoff_is_capped_at_max():
+    _clear()
+    for _ in range(40):  # drive the failure count very high
+        main._record_failure("idcap001")
+    # Capped at MAX (plus at most the 10% jitter).
+    assert main._backoff_delay["idcap001"] <= main.RETRY_BACKOFF_MAX * 1.1 + 1
+
+
+def test_success_resets_backoff():
+    _clear()
+    main._record_failure("idok0001")
+    assert main._backoff_delay["idok0001"] > 0
+    assert "idok0001" in main._next_check_ts
+
+    prev = main._record_success("idok0001", TestFlightStatus.OPEN)
+    assert prev is None
+    assert main._failure_count["idok0001"] == 0
+    assert main._backoff_delay["idok0001"] == 0.0
+    assert "idok0001" not in main._next_check_ts  # next eligible retry cleared
+
+
+def test_cooldown_skips_only_failing_id(monkeypatch):
+    _clear()
+    now = time.time()
+    main._next_check_ts["coolID01"] = now + 1000  # still cooling down
+    # "okID0001" has no next_check_ts -> eligible immediately.
+
+    checked = []
+
+    async def fake_fetch(session, tf_id):
+        checked.append(tf_id)
+
+    async def fake_session():
+        return object()
+
+    monkeypatch.setattr(main, "get_current_id_list", lambda: ["coolID01", "okID0001"])
+    monkeypatch.setattr(main, "get_http_session", fake_session)
+    monkeypatch.setattr(main, "fetch_testflight_status", fake_fetch)
+
+    asyncio.run(main.watch())
+
+    assert "okID0001" in checked  # other IDs keep checking
+    assert "coolID01" not in checked  # the cooling-down ID is skipped
+    # Skipping must NOT be treated as a new failure.
+    assert "coolID01" not in main._failure_count
+
+
+def test_backoff_state_survives_restart():
+    _clear()
+    main._record_failure("idpersist")
+    snap = main.snapshot_runtime_state()
+    rec = snap["apps"]["idpersist"]
+    assert rec["failure_count"] == 1
+    assert rec["next_check_ts"] is not None
+    assert rec["backoff_delay"] > 0
+
+    _clear()
+    main.restore_runtime_state(snap)
+    assert main._failure_count["idpersist"] == 1
+    assert main._next_check_ts["idpersist"] == rec["next_check_ts"]
+    assert main._backoff_delay["idpersist"] == rec["backoff_delay"]
+    # Still in cooldown immediately after restore.
+    assert main._is_in_cooldown("idpersist", time.time()) is True


### PR DESCRIPTION
**Runbook 2 — Task 8.** Per-ID retry/backoff so one broken TestFlight ID can't slow down or spam checks for the others.

## Per-ID state
In addition to the existing consecutive failure count, each ID now tracks **last failure timestamp**, **next eligible check timestamp**, and the **current backoff delay**.

## Behavior
- **On success** (`_record_success`): reset failure count, reset backoff, clear the next-eligible retry time.
- **On failure** (`_record_failure`): increment failure count, grow the delay **exponentially with jitter** up to `RETRY_BACKOFF_MAX`, set the next eligible check time.
- **Cooldown**: `watch()` filters out only the IDs still in their cooldown window and checks the rest concurrently (as before). A skipped ID is **not** counted as a new failure, and the watch loop still sleeps between cycles — no busy loop.

## State integration (Task 7)
The three new fields are included in `snapshot_runtime_state()` / `restore_runtime_state()`, so a cooldown (`next_check_ts` is absolute) **survives a restart**.

## Config (existing pattern)
`RETRY_BACKOFF_BASE_SECONDS` (default `30`) and `RETRY_BACKOFF_MAX_SECONDS` (default `3600`), documented in the README.

## Constraints honored
Notification decision logic unchanged (the success/failure recording was refactored into helpers that preserve the previous behavior); no unrelated refactors.

## Tests (`tests/test_retry.py`)
Failure increases backoff · backoff capped at max · success resets backoff · cooldown skips only the failing ID while others keep checking (and the skip isn't a failure) · backoff state survives restart. Full suite: **61 passed**, pyflakes clean.

## Manual verification
Ran with `RETRY_BACKOFF_BASE_SECONDS=2`, a failing ID, and `INTERVAL_CHECK=1000`: logs showed `retry in ~2s → ~4s → ~8s` (exponential) with checks spaced further apart each time (cooldown skipping); `data/state.json` persisted `failure_count`, `last_failure_ts`, a future `next_check_ts`, and `backoff_delay` capped near the configured max + jitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)