### PR TITLE
Add config import export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ build/
 # Runtime state persistence
 data/state.json
 data/.state.*.tmp
+.env.backup

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A Python-based monitoring tool that continuously checks Apple TestFlight beta av
 - ⚡ **High Performance** – Async HTTP requests with connection pooling and caching
 - 🔄 **Status Tracking** – Detects status changes (Open, Full, Closed) and notifies accordingly
 - 💾 **State Persistence** – Saves runtime state to disk and resumes after a restart without re-sending duplicate notifications
+- 📦 **Config Import/Export** – Export your monitored IDs and settings to a `config.json` and import them back (secrets excluded by default)
 - 💓 **Heartbeat Notifications** – Optional periodic notifications to confirm the service is running
 - 🧪 **Test Notification** – Send a one-off test message to your configured destinations from the dashboard
 - 🎨 **Dark/Light Theme** – Responsive web dashboard with persistent theme preference
@@ -211,7 +212,7 @@ Once running, access the web dashboard at `http://localhost:8080` (or your confi
 - **Dashboard** – Live status of all monitored betas, uptime, metrics, and service controls (start/stop/restart)
 - **TestFlight IDs** – Add or remove IDs to monitor without restarting
 - **Apprise URLs** – Add or remove notification endpoints on the fly, and send a test notification to confirm they work
-- **Settings** – Toggle options (update checker, always-notify), change the default theme, and edit the `.env` file directly with the built-in editor
+- **Settings** – Toggle options (update checker, always-notify), change the default theme, edit the `.env` file directly with the built-in editor, and import/export your configuration as `config.json`
 - **Logs** – Filterable live log viewer with level and line-count controls
 
 ### API Endpoints
@@ -235,6 +236,8 @@ Interactive OpenAPI docs are available at `/docs`.
 | `/api/config` | GET / POST | Read or write the `.env` configuration file |
 | `/api/control/stop` | POST | Stop the service |
 | `/api/control/restart` | POST | Restart the service (re-executes in place) |
+| `/api/config/export` | GET | Export portable config (IDs + settings); `?include_secrets=true` to include raw Apprise URLs |
+| `/api/config/import` | POST | Import a `config.json` (validated; restart to apply) |
 | `/api/test-notification` | POST | Send a test notification to the configured Apprise destinations |
 
 ## Dependencies

--- a/config_io.py
+++ b/config_io.py
@@ -1,0 +1,247 @@
+"""
+Portable configuration import/export.
+
+Exports the non-secret, runtime-independent configuration (monitored TestFlight
+IDs and user-facing settings) and validates such a structure before importing
+it. Secrets (raw Apprise URLs/tokens, dashboard credentials) and runtime state
+(status, failure counts, timestamps, cooldowns, cached icons) are excluded by
+default; raw Apprise URLs are only included when secrets are explicitly
+requested. Imports are validated in full before anything is written, and are
+applied with a single atomic .env rewrite (no partial application).
+"""
+
+import logging
+import os
+import shutil
+import tempfile
+
+import config
+import state
+
+EXPORT_VERSION = 1
+
+# Allowed top-level keys in an imported config (anything else is rejected).
+_ALLOWED_TOP_LEVEL = {
+    "version",
+    "exported_at",
+    "testflight_ids",
+    "settings",
+    "notifications",
+    "apprise_urls",
+    "_warning",
+}
+# Allowed setting keys.
+_ALLOWED_SETTINGS = {
+    "always_notify_open",
+    "enable_update_checker",
+    "ui_theme",
+    "interval_check_ms",
+    "heartbeat_interval_hours",
+}
+
+
+def build_export(include_secrets: bool = False) -> dict:
+    """Build the portable export structure.
+
+    Excludes secrets and runtime state by default. When ``include_secrets`` is
+    True the raw Apprise URLs are added along with a clear warning.
+    """
+    urls = state.get_current_apprise_urls()
+    from utils.service_icons import get_apprise_service_icon
+
+    services = sorted({get_apprise_service_icon(u)["service_name"] for u in urls})
+
+    data = {
+        "version": EXPORT_VERSION,
+        "testflight_ids": state.get_current_id_list(),
+        "settings": {
+            "always_notify_open": config.ALWAYS_NOTIFY_OPEN,
+            "enable_update_checker": config.ENABLE_UPDATE_CHECKER,
+            "ui_theme": config.UI_THEME,
+            "interval_check_ms": config.SLEEP_TIME,
+            "heartbeat_interval_hours": config.HEARTBEAT_INTERVAL // 3600,
+        },
+        # Non-secret notification metadata only (service names, never URLs/tokens).
+        "notifications": {
+            "configured_count": len(urls),
+            "services": services,
+        },
+    }
+    if include_secrets:
+        data["_warning"] = (
+            "This file contains secret Apprise URLs. Keep it private and do not "
+            "share or commit it."
+        )
+        data["apprise_urls"] = urls
+    return data
+
+
+def validate_import(data) -> tuple:
+    """Validate an imported config structure.
+
+    Returns ``(normalized, None)`` on success or ``(None, error_message)`` on
+    failure. Nothing is written here, so a rejected import applies nothing.
+    """
+    if not isinstance(data, dict):
+        return None, "Config must be a JSON object"
+
+    unknown = set(data) - _ALLOWED_TOP_LEVEL
+    if unknown:
+        return None, f"Unknown field(s): {', '.join(sorted(unknown))}"
+
+    normalized = {}
+
+    if "testflight_ids" in data:
+        ids = data["testflight_ids"]
+        if not isinstance(ids, list) or not all(isinstance(i, str) for i in ids):
+            return None, "testflight_ids must be a list of strings"
+        cleaned = []
+        for tf in ids:
+            tf = tf.strip()
+            ok, _ = state.validate_testflight_id_format(tf)
+            if not ok:
+                return None, f"Invalid TestFlight ID: {tf!r}"
+            cleaned.append(tf)
+        normalized["testflight_ids"] = cleaned
+
+    if "settings" in data:
+        settings = data["settings"]
+        if not isinstance(settings, dict):
+            return None, "settings must be an object"
+        unknown_s = set(settings) - _ALLOWED_SETTINGS
+        if unknown_s:
+            return None, f"Unknown setting(s): {', '.join(sorted(unknown_s))}"
+        norm_s = {}
+        for key in ("always_notify_open", "enable_update_checker"):
+            if key in settings:
+                if not isinstance(settings[key], bool):
+                    return None, f"{key} must be a boolean"
+                norm_s[key] = settings[key]
+        if "ui_theme" in settings:
+            if settings["ui_theme"] not in ("dark", "light"):
+                return None, "ui_theme must be 'dark' or 'light'"
+            norm_s["ui_theme"] = settings["ui_theme"]
+        if "interval_check_ms" in settings:
+            v = settings["interval_check_ms"]
+            if not isinstance(v, int) or isinstance(v, bool) or v < 1000:
+                return None, "interval_check_ms must be an integer >= 1000"
+            norm_s["interval_check_ms"] = v
+        if "heartbeat_interval_hours" in settings:
+            v = settings["heartbeat_interval_hours"]
+            if not isinstance(v, int) or isinstance(v, bool) or v < 0:
+                return None, "heartbeat_interval_hours must be a non-negative integer"
+            norm_s["heartbeat_interval_hours"] = v
+        normalized["settings"] = norm_s
+
+    # Replacement secrets are only honored if explicitly present in the import.
+    if "apprise_urls" in data:
+        urls = data["apprise_urls"]
+        if not isinstance(urls, list) or not all(isinstance(u, str) for u in urls):
+            return None, "apprise_urls must be a list of strings"
+        normalized["apprise_urls"] = [u.strip() for u in urls if u.strip()]
+
+    return normalized, None
+
+
+def _format_value(key, value):
+    """Format a key's .env line(s): scalar as KEY=value, list in comma form."""
+    if isinstance(value, list):
+        if not value:
+            return [f"{key}=\n"]
+        out = [f"{key}={value[0]},\n"]
+        out += [f"{v},\n" for v in value[1:]]
+        return out
+    return [f"{key}={value}\n"]
+
+
+def _apply_env_updates(content: str, updates: dict) -> str:
+    """Return new .env text with the given keys replaced; everything else kept.
+
+    Other lines (comments, blank lines, untouched keys) are preserved in order.
+    Keys not already present are appended.
+    """
+    lines = content.splitlines(keepends=True)
+    if lines and not lines[-1].endswith("\n"):
+        lines[-1] += "\n"
+
+    new_lines = []
+    inserted = set()
+    i = 0
+    while i < len(lines):
+        stripped = lines[i].strip()
+        matched = next((k for k in updates if stripped.startswith(f"{k}=")), None)
+        if matched is not None:
+            if matched not in inserted:
+                new_lines.extend(_format_value(matched, updates[matched]))
+                inserted.add(matched)
+            # Skip the old key line and any continuation lines.
+            i += 1
+            while i < len(lines):
+                nxt = lines[i].strip()
+                if not nxt or nxt.startswith("#") or "=" in nxt:
+                    break
+                i += 1
+            continue
+        new_lines.append(lines[i])
+        i += 1
+
+    for key in updates:
+        if key not in inserted:
+            new_lines.extend(_format_value(key, updates[key]))
+    return "".join(new_lines)
+
+
+def apply_import(normalized: dict) -> bool:
+    """Apply a validated import as a single atomic .env rewrite.
+
+    Existing secrets are preserved unless ``apprise_urls`` is present in the
+    import. Returns True on success.
+    """
+    updates = {}
+    if "testflight_ids" in normalized:
+        updates["ID_LIST"] = normalized["testflight_ids"]
+    if "apprise_urls" in normalized:
+        updates["APPRISE_URL"] = normalized["apprise_urls"]
+    settings = normalized.get("settings", {})
+    if "always_notify_open" in settings:
+        updates["ALWAYS_NOTIFY_OPEN"] = "true" if settings["always_notify_open"] else "false"
+    if "enable_update_checker" in settings:
+        updates["ENABLE_UPDATE_CHECKER"] = (
+            "true" if settings["enable_update_checker"] else "false"
+        )
+    if "ui_theme" in settings:
+        updates["UI_THEME"] = settings["ui_theme"]
+    if "interval_check_ms" in settings:
+        updates["INTERVAL_CHECK"] = str(settings["interval_check_ms"])
+    if "heartbeat_interval_hours" in settings:
+        updates["HEARTBEAT_INTERVAL"] = str(settings["heartbeat_interval_hours"])
+
+    if not updates:
+        return True
+
+    env_path = ".env"
+    backup_path = f"{env_path}.backup"
+    try:
+        current = ""
+        if os.path.exists(env_path):
+            with open(env_path, "r") as f:
+                current = f.read()
+        new_content = _apply_env_updates(current, updates)
+
+        directory = os.path.dirname(os.path.abspath(env_path)) or "."
+        if os.path.exists(env_path):
+            shutil.copy2(env_path, backup_path)
+        fd, tmp_path = tempfile.mkstemp(prefix=".env.", suffix=".tmp", dir=directory)
+        try:
+            with os.fdopen(fd, "w") as tmp:
+                tmp.write(new_content)
+                tmp.flush()
+                os.fsync(tmp.fileno())
+            os.replace(tmp_path, env_path)
+        finally:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+        return True
+    except OSError as e:
+        logging.error("Failed to write imported config: %s", e)
+        return False

--- a/routes.py
+++ b/routes.py
@@ -10,6 +10,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel, Field
 
+import config_io
 import state
 from state import (
     apobj,
@@ -593,6 +594,48 @@ async def restore_config():
     except Exception as e:
         logging.error(f"Failed to restore .env file: {e}")
         raise HTTPException(status_code=500, detail=f"Failed to restore config: {str(e)}")
+
+
+@router.get("/api/config/export")
+async def export_config(include_secrets: bool = False):
+    """Export portable configuration (monitored IDs + settings).
+
+    Secrets and runtime state are excluded by default. ``include_secrets=true``
+    must be set explicitly to include raw Apprise URLs, and is warned about.
+    """
+    if include_secrets:
+        logging.warning(
+            "Config export requested WITH secrets - the file will contain raw "
+            "Apprise URLs"
+        )
+    return config_io.build_export(include_secrets=include_secrets)
+
+
+@router.post("/api/config/import")
+async def import_config(request: Request):
+    """Import a portable configuration file.
+
+    Validates the whole structure before applying; malformed JSON, unknown
+    fields, or invalid values are rejected without writing anything. State-
+    changing, so the existing CSRF protection applies.
+    """
+    try:
+        data = await request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="Malformed JSON")
+
+    normalized, error = config_io.validate_import(data)
+    if error:
+        raise HTTPException(status_code=400, detail=error)
+
+    if not config_io.apply_import(normalized):
+        raise HTTPException(status_code=500, detail="Failed to write imported config")
+
+    logging.info("Configuration imported via web interface")
+    return {
+        "success": True,
+        "message": "Configuration imported. Restart to apply changes.",
+    }
 
 
 @router.get("/config")

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -502,6 +502,59 @@ async function saveAndRestart() {
   }
 }
 
+/* ── Config import / export ─────────────────────────────────── */
+async function exportConfig() {
+  const statusDiv = document.getElementById('import-export-status');
+  try {
+    const res = await fetch('/api/config/export');
+    if (!res.ok) { setStatus(statusDiv, 'Export failed.', 'error'); return; }
+    const data = await res.json();
+    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = 'config.json';
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(a.href);
+    setStatus(statusDiv, 'Configuration exported.', 'success');
+  } catch (e) {
+    setStatus(statusDiv, `Error: ${e.message}`, 'error');
+  }
+}
+
+function triggerImportConfig() {
+  document.getElementById('import-config-file').click();
+}
+
+async function importConfig(input) {
+  const statusDiv = document.getElementById('import-export-status');
+  const file = input.files && input.files[0];
+  if (!file) return;
+  try {
+    const text = await file.text();
+    let parsed;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      setStatus(statusDiv, 'Selected file is not valid JSON.', 'error');
+      return;
+    }
+    const res  = await fetch('/api/config/import', jsonPost(parsed));
+    const data = await res.json();
+    if (res.ok) {
+      setStatus(statusDiv, data.message || 'Configuration imported.', 'success');
+      showToast('Configuration imported', 'success', 'Imported');
+    } else {
+      setStatus(statusDiv, data.detail || 'Import failed.', 'error');
+    }
+  } catch (e) {
+    setStatus(statusDiv, `Error: ${e.message}`, 'error');
+  } finally {
+    input.value = '';
+  }
+}
+
 async function saveToggles() {
   const statusDiv = document.getElementById('toggle-status');
   const updateChecker = document.getElementById('toggle-update-checker').checked;

--- a/templates/index.html
+++ b/templates/index.html
@@ -402,6 +402,20 @@
             <div id="config-status" class="status-msg" role="status" aria-live="polite"></div>
           </div>
         </div>
+
+        <!-- Import / Export -->
+        <div class="card">
+          <div class="card-header"><h3>Import / Export Configuration</h3></div>
+          <div class="card-body">
+            <p class="text-muted text-sm mb-2">Export your monitored TestFlight IDs and settings to a <code>config.json</code> file (no secrets). Import replaces them; restart to apply.</p>
+            <div class="btn-group">
+              <button class="btn btn-secondary" onclick="exportConfig()">Export Config</button>
+              <button class="btn btn-secondary" onclick="triggerImportConfig()">Import Config</button>
+              <input type="file" id="import-config-file" accept="application/json,.json" style="display:none" onchange="importConfig(this)">
+            </div>
+            <div id="import-export-status" class="status-msg" role="status" aria-live="polite"></div>
+          </div>
+        </div>
       </section>
 
       <!-- ═══════════════════════════════════

--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -1,0 +1,161 @@
+"""Tests for configuration import/export (Runbook 2 — Task 9)."""
+
+import json
+import os
+
+os.environ.setdefault("APPRISE_URL", "json://localhost/")
+os.environ.setdefault("ENABLE_UPDATE_CHECKER", "false")
+os.environ.pop("WEB_USERNAME", None)
+os.environ.pop("WEB_PASSWORD", None)
+
+import pytest
+from fastapi.testclient import TestClient
+
+import config_io  # noqa: E402
+import main  # noqa: E402
+import state  # noqa: E402
+
+
+@pytest.fixture
+def client():
+    c = TestClient(main.app)
+    c.get("/")  # obtain a CSRF cookie
+    token = c.cookies.get("csrf_token")
+    if token:
+        c.headers.update({"X-CSRF-Token": token})
+    return c
+
+
+# ── Export ──────────────────────────────────────────────────────
+def test_export_excludes_secrets_by_default(client):
+    saved = list(state.current_apprise_urls)
+    try:
+        state.current_apprise_urls[:] = ["discord://id999/SECRETTOKEN123"]
+        body = client.get("/api/config/export").json()
+        blob = json.dumps(body)
+        assert "apprise_urls" not in body  # raw URLs not exported
+        assert "SECRETTOKEN123" not in blob  # no token anywhere
+        assert "discord://" not in blob
+        # Non-secret service metadata is fine.
+        assert body["notifications"]["services"] == ["Discord"]
+    finally:
+        state.current_apprise_urls[:] = saved
+
+
+def test_export_includes_secrets_only_when_requested(client):
+    saved = list(state.current_apprise_urls)
+    try:
+        state.current_apprise_urls[:] = ["discord://id999/SECRETTOKEN123"]
+        body = client.get("/api/config/export?include_secrets=true").json()
+        assert body["apprise_urls"] == ["discord://id999/SECRETTOKEN123"]
+        assert "_warning" in body  # user is warned
+    finally:
+        state.current_apprise_urls[:] = saved
+
+
+def test_export_excludes_runtime_state(client):
+    body = client.get("/api/config/export").json()
+    blob = json.dumps(body)
+    for runtime_key in (
+        "failure_count",
+        "next_check_ts",
+        "last_success_ts",
+        "last_failure_ts",
+        "backoff_delay",
+        "notified_open",
+        "icon_url",
+    ):
+        assert runtime_key not in blob
+    assert set(body) <= {"version", "testflight_ids", "settings", "notifications"}
+
+
+# ── Import validation (no writes) ───────────────────────────────
+def test_validate_rejects_unknown_fields():
+    normalized, error = config_io.validate_import({"evil_field": 1})
+    assert normalized is None and "Unknown field" in error
+
+
+def test_validate_rejects_bad_id():
+    normalized, error = config_io.validate_import({"testflight_ids": ["!bad!"]})
+    assert normalized is None and "Invalid TestFlight ID" in error
+
+
+def test_validate_rejects_unknown_setting():
+    normalized, error = config_io.validate_import({"settings": {"rm_rf": True}})
+    assert normalized is None and "Unknown setting" in error
+
+
+# ── Import via endpoint ─────────────────────────────────────────
+def test_import_malformed_json_rejected(client):
+    r = client.post(
+        "/api/config/import",
+        content="{ this is not json ",
+        headers={"Content-Type": "application/json"},
+    )
+    assert r.status_code == 400
+
+
+def test_import_unsafe_fields_rejected(client):
+    r = client.post("/api/config/import", json={"settings": {"danger": 1}})
+    assert r.status_code == 400
+
+
+def test_import_valid_returns_ok(client, monkeypatch):
+    # Stub the write so the test doesn't touch the repo's .env.
+    monkeypatch.setattr(config_io, "apply_import", lambda n: True)
+    r = client.post(
+        "/api/config/import",
+        json={"version": 1, "testflight_ids": ["abcd1234"], "settings": {"ui_theme": "light"}},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["success"] is True
+
+
+def test_import_requires_csrf():
+    c = TestClient(main.app)  # fresh client, no CSRF token
+    assert c.post("/api/config/import", json={"version": 1}).status_code == 403
+
+
+# ── Apply (atomic .env write) ───────────────────────────────────
+def test_apply_import_writes_atomically_and_preserves_secret(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    env = tmp_path / ".env"
+    env.write_text(
+        "# my config\n"
+        "ID_LIST=old111,\n"
+        "APPRISE_URL=discord://keep/THISSECRET,\n"
+        "UI_THEME=dark\n"
+    )
+    data = {
+        "version": 1,
+        "testflight_ids": ["newid001", "newid002"],
+        "settings": {"ui_theme": "light", "always_notify_open": True},
+    }
+    normalized, error = config_io.validate_import(data)
+    assert error is None
+    assert config_io.apply_import(normalized) is True
+
+    content = env.read_text()
+    assert "newid001" in content and "newid002" in content
+    assert "old111" not in content
+    assert "discord://keep/THISSECRET" in content  # secret preserved (not in import)
+    assert "UI_THEME=light" in content
+    assert "ALWAYS_NOTIFY_OPEN=true" in content
+    assert "# my config" in content  # comments preserved
+    assert (tmp_path / ".env.backup").exists()  # hardened backup
+    assert not [p for p in tmp_path.iterdir() if p.name.endswith(".tmp")]
+
+
+def test_invalid_import_does_not_apply(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    env = tmp_path / ".env"
+    original = "ID_LIST=keepme12,\nAPPRISE_URL=discord://a/b,\n"
+    env.write_text(original)
+
+    # Valid IDs but an invalid setting -> the whole import is rejected.
+    normalized, error = config_io.validate_import(
+        {"testflight_ids": ["validid1"], "settings": {"interval_check_ms": 1}}
+    )
+    assert normalized is None and error  # rejected
+    # The caller never applies, so the file is untouched (no partial apply).
+    assert env.read_text() == original


### PR DESCRIPTION
**Runbook 2 — Task 9.** Portable import/export of monitored TestFlight IDs and user-facing settings.

## Export — `GET /api/config/export`
Produces a `config.json` with `testflight_ids`, `settings` (theme, interval, heartbeat, toggles), and non-secret `notifications` metadata (**service names only**, e.g. `["Discord"]`). **Excluded by default:** raw Apprise URLs/tokens, dashboard credentials, and all runtime state (status, failure counts, timestamps, cooldowns, cached icons). `?include_secrets=true` is **explicit, defaults to false**, includes the raw Apprise URLs, and adds a clear `_warning` (and logs a warning).

## Import — `POST /api/config/import`
- **Validates the whole structure first** — allowlisted top-level keys and setting keys, TestFlight ID format, value types. Malformed JSON, unknown fields, or invalid values are rejected (`400`) and **nothing is written** (no partial apply).
- **Single atomic `.env` rewrite** (temp + `fsync` + `os.replace` + `.env.backup`), preserving comments/order.
- **Existing secrets are preserved** unless the import explicitly includes `apprise_urls`.
- State-changing POST → covered by the existing **CSRF** protection (and app auth).

## Dashboard
Simple **Export / Import** buttons in Settings (client-side `config.json` download; file picker that POSTs the parsed JSON). Kept minimal.

## Tests (`tests/test_config_io.py`, 12)
Export excludes secrets by default · export excludes runtime state · `include_secrets` adds URLs + warning · validate rejects unknown fields / bad ID / unknown setting · import malformed JSON → 400 · import unsafe fields → 400 · valid import → 200 · **CSRF required** on import → 403 · apply writes atomically, preserves the existing secret + comments, makes a backup · invalid import does not apply (file untouched). Full suite: **73 passed**, pyflakes clean.

## Manual verification
Ran the app: default export contained no secret (`REALSECRETTOKEN` absent) and no runtime keys; `?include_secrets=true` added `apprise_urls` + `_warning`; a valid import (with CSRF) returned 200 and rewrote `.env` (`ID_LIST`/`UI_THEME`/`ALWAYS_NOTIFY_OPEN` updated, **`APPRISE_URL` preserved**); malformed → 400; no-CSRF → 403. Browser-checked the two Settings buttons + file input exist and `exportConfig()` hits `/api/config/export`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)