### PR TITLE
Add per app configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ build/
 data/state.json
 data/.state.*.tmp
 .env.backup
+data/app_config.json
+data/.app_config.*.tmp

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A Python-based monitoring tool that continuously checks Apple TestFlight beta av
 - 🔄 **Status Tracking** – Detects status changes (Open, Full, Closed) and notifies accordingly
 - 💾 **State Persistence** – Saves runtime state to disk and resumes after a restart without re-sending duplicate notifications
 - 📦 **Config Import/Export** – Export your monitored IDs and settings to a `config.json` and import them back (secrets excluded by default)
+- 🎛️ **Per-App Settings** – Enable/disable, friendly name, check-interval override, and per-status notification toggles for each monitored ID
 - 💓 **Heartbeat Notifications** – Optional periodic notifications to confirm the service is running
 - 🧪 **Test Notification** – Send a one-off test message to your configured destinations from the dashboard
 - 🎨 **Dark/Light Theme** – Responsive web dashboard with persistent theme preference
@@ -117,6 +118,7 @@ All configuration is done through environment variables in the `.env` file. You 
 | `GITHUB_BRANCH` | `main` | Branch to compare against for update checks |
 | `UI_THEME` | `dark` | Default web dashboard theme (`dark` or `light`) |
 | `STATE_FILE` | `data/state.json` | Where runtime state is persisted (per-ID status, timestamps, failure counts, cached app name/icon) so monitoring resumes cleanly after a restart |
+| `APP_CONFIG_FILE` | `data/app_config.json` | Where per-app configuration (enabled, friendly name, check-interval override, notification toggles) is stored — separate from the runtime state file |
 | `FASTAPI_HOST` | `127.0.0.1` | Web dashboard bind address (set `0.0.0.0` to expose it) |
 | `FASTAPI_PORT` | random `8000–9000` | Web dashboard port (set explicitly to keep it stable) |
 | `WEB_USERNAME` | _(unset)_ | Username for optional HTTP Basic auth on the dashboard/API |
@@ -210,7 +212,7 @@ Once running, access the web dashboard at `http://localhost:8080` (or your confi
 ### Dashboard Sections
 
 - **Dashboard** – Live status of all monitored betas, uptime, metrics, and service controls (start/stop/restart)
-- **TestFlight IDs** – Add or remove IDs to monitor without restarting
+- **TestFlight IDs** – Add or remove IDs to monitor without restarting, and configure each app individually (enable/disable, friendly name, check-interval override, per-status notification toggles)
 - **Apprise URLs** – Add or remove notification endpoints on the fly, and send a test notification to confirm they work
 - **Settings** – Toggle options (update checker, always-notify), change the default theme, edit the `.env` file directly with the built-in editor, and import/export your configuration as `config.json`
 - **Logs** – Filterable live log viewer with level and line-count controls
@@ -228,7 +230,8 @@ Interactive OpenAPI docs are available at `/docs`.
 | `/api/logs` | GET | Recent log entries (`?limit=` 1–1000) |
 | `/api/updates` | GET | Check GitHub for a newer version (`?force=true` to bypass cache) |
 | `/api/testflight-ids` | GET / POST | List or add a monitored TestFlight ID |
-| `/api/testflight-ids/details` | GET | Monitored IDs with app names and icons |
+| `/api/testflight-ids/details` | GET | Monitored IDs with app names, icons, and per-app settings |
+| `/api/testflight-ids/{id}/settings` | POST | Update per-app settings (enabled, friendly name, interval, notify toggles) |
 | `/api/testflight-ids/{id}` | DELETE | Remove a TestFlight ID |
 | `/api/testflight-ids/batch` | POST | Add/remove multiple IDs at once |
 | `/api/apprise-urls` | GET / POST | List or add an Apprise notification URL |

--- a/app_config.py
+++ b/app_config.py
@@ -1,0 +1,150 @@
+"""
+Per-app configuration for monitored TestFlight IDs.
+
+Holds optional per-ID settings (enabled, friendly name, check-interval override,
+and per-status notification toggles) in a JSON config file, separate from both
+the simple `.env` ID list (backward compatible) and the runtime state file.
+An ID with no entry uses defaults that preserve the original behavior.
+"""
+
+import json
+import logging
+import os
+import tempfile
+import threading
+
+APP_CONFIG_FILE = os.getenv("APP_CONFIG_FILE", "data/app_config.json")
+CONFIG_VERSION = 1
+
+# Defaults chosen to preserve the original behavior: every app enabled, no
+# friendly name, global interval, OPEN/FULL notifications on, CLOSED off.
+DEFAULTS = {
+    "enabled": True,
+    "friendly_name": None,
+    "check_interval_seconds": None,
+    "notify_on_open": True,
+    "notify_on_full": True,
+    "notify_on_closed": False,
+}
+
+_settings = {}  # tf_id -> partial settings dict (validated)
+_lock = threading.Lock()
+
+
+def get(tf_id: str) -> dict:
+    """Return the effective settings for an ID (defaults merged with overrides)."""
+    with _lock:
+        stored = dict(_settings.get(tf_id, {}))
+    merged = dict(DEFAULTS)
+    merged.update(stored)
+    return merged
+
+
+def get_all() -> dict:
+    """Return all stored per-app overrides (no defaults), for export."""
+    with _lock:
+        return {k: dict(v) for k, v in _settings.items()}
+
+
+def validate(partial) -> tuple:
+    """Validate a partial settings dict. Returns (normalized, None) or (None, err)."""
+    if not isinstance(partial, dict):
+        return None, "settings must be an object"
+    unknown = set(partial) - set(DEFAULTS)
+    if unknown:
+        return None, f"Unknown setting(s): {', '.join(sorted(unknown))}"
+
+    norm = {}
+    for key in ("enabled", "notify_on_open", "notify_on_full", "notify_on_closed"):
+        if key in partial:
+            if not isinstance(partial[key], bool):
+                return None, f"{key} must be a boolean"
+            norm[key] = partial[key]
+    if "friendly_name" in partial:
+        v = partial["friendly_name"]
+        if v is not None and (not isinstance(v, str) or len(v) > 100):
+            return None, "friendly_name must be a string (<=100 chars) or null"
+        norm["friendly_name"] = v.strip() if isinstance(v, str) else v
+    if "check_interval_seconds" in partial:
+        v = partial["check_interval_seconds"]
+        if v is not None and (not isinstance(v, int) or isinstance(v, bool) or v < 1):
+            return None, "check_interval_seconds must be a positive integer or null"
+        norm["check_interval_seconds"] = v
+    return norm, None
+
+
+def update(tf_id: str, partial) -> tuple:
+    """Validate and merge new settings for an ID, then persist. Returns (ok, msg)."""
+    norm, error = validate(partial)
+    if error:
+        return False, error
+    with _lock:
+        current = dict(_settings.get(tf_id, {}))
+        current.update(norm)
+        _settings[tf_id] = current
+    _save()
+    return True, "Settings updated"
+
+
+def replace_all(mapping) -> tuple:
+    """Validate and replace per-app settings for the given IDs (used by import).
+
+    Validates every entry before applying any, so an invalid mapping is rejected
+    in full. Returns (ok, error). Only the provided IDs are updated.
+    """
+    if not isinstance(mapping, dict):
+        return False, "app_settings must be an object"
+    validated = {}
+    for tf_id, partial in mapping.items():
+        norm, error = validate(partial)
+        if error:
+            return False, f"{tf_id}: {error}"
+        validated[tf_id] = norm
+    with _lock:
+        for tf_id, norm in validated.items():
+            _settings[tf_id] = norm
+    _save()
+    return True, "ok"
+
+
+def load_from_disk() -> None:
+    """Load per-app config from disk. Tolerates a missing or corrupt file."""
+    global _settings
+    try:
+        if not os.path.exists(APP_CONFIG_FILE):
+            return
+        with open(APP_CONFIG_FILE, "r") as f:
+            data = json.load(f)
+        apps = data.get("apps", {}) if isinstance(data, dict) else {}
+        loaded = {}
+        for tf_id, partial in (apps or {}).items():
+            norm, error = validate(partial)
+            if error:
+                logging.warning("Ignoring invalid per-app config for %s: %s", tf_id, error)
+                continue
+            loaded[tf_id] = norm
+        with _lock:
+            _settings = loaded
+    except (json.JSONDecodeError, ValueError, OSError) as e:
+        logging.warning("Could not load per-app config (%s); using defaults", e)
+
+
+def _save() -> None:
+    """Atomically write the per-app config to disk (best effort)."""
+    with _lock:
+        data = {"version": CONFIG_VERSION, "apps": {k: dict(v) for k, v in _settings.items()}}
+    try:
+        directory = os.path.dirname(os.path.abspath(APP_CONFIG_FILE)) or "."
+        os.makedirs(directory, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(prefix=".app_config.", suffix=".tmp", dir=directory)
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(data, f, indent=2)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, APP_CONFIG_FILE)
+        finally:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+    except OSError as e:
+        logging.error("Failed to save per-app config: %s", e)

--- a/config_io.py
+++ b/config_io.py
@@ -15,6 +15,7 @@ import os
 import shutil
 import tempfile
 
+import app_config
 import config
 import state
 
@@ -26,6 +27,7 @@ _ALLOWED_TOP_LEVEL = {
     "exported_at",
     "testflight_ids",
     "settings",
+    "app_settings",
     "notifications",
     "apprise_urls",
     "_warning",
@@ -61,6 +63,8 @@ def build_export(include_secrets: bool = False) -> dict:
             "interval_check_ms": config.SLEEP_TIME,
             "heartbeat_interval_hours": config.HEARTBEAT_INTERVAL // 3600,
         },
+        # Per-app overrides (enabled, friendly names, toggles); non-secret.
+        "app_settings": app_config.get_all(),
         # Non-secret notification metadata only (service names, never URLs/tokens).
         "notifications": {
             "configured_count": len(urls),
@@ -132,6 +136,18 @@ def validate_import(data) -> tuple:
                 return None, "heartbeat_interval_hours must be a non-negative integer"
             norm_s["heartbeat_interval_hours"] = v
         normalized["settings"] = norm_s
+
+    if "app_settings" in data:
+        apps = data["app_settings"]
+        if not isinstance(apps, dict):
+            return None, "app_settings must be an object"
+        norm_apps = {}
+        for tf_id, partial in apps.items():
+            norm, error = app_config.validate(partial)
+            if error:
+                return None, f"app_settings[{tf_id}]: {error}"
+            norm_apps[tf_id] = norm
+        normalized["app_settings"] = norm_apps
 
     # Replacement secrets are only honored if explicitly present in the import.
     if "apprise_urls" in data:
@@ -216,9 +232,19 @@ def apply_import(normalized: dict) -> bool:
     if "heartbeat_interval_hours" in settings:
         updates["HEARTBEAT_INTERVAL"] = str(settings["heartbeat_interval_hours"])
 
-    if not updates:
-        return True
+    env_ok = True
+    if updates:
+        env_ok = _write_env_updates(updates)
 
+    # Per-app settings live in their own config file (separate from .env).
+    if env_ok and "app_settings" in normalized:
+        app_config.replace_all(normalized["app_settings"])
+
+    return env_ok
+
+
+def _write_env_updates(updates: dict) -> bool:
+    """Apply key updates to .env as a single atomic, backed-up rewrite."""
     env_path = ".env"
     backup_path = f"{env_path}.backup"
     try:

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ import random
 import secrets
 import time
 import persistence
+import app_config
 from contextlib import asynccontextmanager
 from fastapi import FastAPI, HTTPException, Request, Depends
 from fastapi.responses import JSONResponse
@@ -114,6 +115,9 @@ _failure_count: Dict[str, int] = {}  # tf_id -> consecutive failures
 _last_failure_ts: Dict[str, float] = {}  # tf_id -> epoch seconds
 _next_check_ts: Dict[str, float] = {}  # tf_id -> earliest epoch seconds to retry
 _backoff_delay: Dict[str, float] = {}  # tf_id -> current backoff delay (seconds)
+
+# Last time each ID was checked, for honoring per-app check-interval overrides.
+_last_check_ts: Dict[str, float] = {}  # tf_id -> epoch seconds
 
 
 def _record_failure(tf_id: str) -> float:
@@ -433,6 +437,10 @@ async def fetch_testflight_status(session, tf_id):
         if not app_name:
             app_name = await get_app_name(TESTFLIGHT_URL, tf_id)
 
+        # Per-app settings; a friendly name overrides the detected name.
+        settings = app_config.get(tf_id)
+        display_name = settings["friendly_name"] or app_name
+
         # Get current and previous status (a successful check clears backoff)
         current_status = result["status"]
         previous_status = _record_success(tf_id, current_status)
@@ -443,47 +451,61 @@ async def fetch_testflight_status(session, tf_id):
 
         # Handle different status types
         if result["status"] == TestFlightStatus.FULL:
-            logging.info(f"200 - {app_name} - Beta is full")
-            # Only notify on status change to FULL (optional behavior)
-            if status_changed and previous_status == TestFlightStatus.OPEN:
+            logging.info(f"200 - {display_name} - Beta is full")
+            # Only notify on the OPEN -> FULL transition, when enabled.
+            if (
+                status_changed
+                and previous_status == TestFlightStatus.OPEN
+                and settings["notify_on_full"]
+            ):
                 should_notify = True
 
         elif result["status"] == TestFlightStatus.CLOSED:
-            logging.info(f"200 - {app_name} - Beta is closed")
-            # Don't notify for closed status
+            logging.info(f"200 - {display_name} - Beta is closed")
+            # Closed notifications are opt-in (default off): notify only on the
+            # transition into CLOSED when enabled.
+            if (
+                status_changed
+                and previous_status not in (None, TestFlightStatus.CLOSED)
+                and settings["notify_on_closed"]
+            ):
+                should_notify = True
 
         elif result["status"] == TestFlightStatus.OPEN:
-            # Decide notification policy for OPEN status
-            with _open_notified_lock:
-                already_notified = _open_notified.get(tf_id, False)
+            if not settings["notify_on_open"]:
+                logging.info(f"200 - {display_name} - Beta is OPEN (open notifications disabled)")
+            else:
+                # Decide notification policy for OPEN status
+                with _open_notified_lock:
+                    already_notified = _open_notified.get(tf_id, False)
 
-                if ALWAYS_NOTIFY_OPEN:
-                    should_notify = True
-                    logging.info(f"200 - {app_name} - Beta is OPEN (forced notification mode)")
-                elif not already_notified:
-                    # First ever OPEN notification for this TestFlight ID
-                    should_notify = True
-                    logging.info(
-                        f"200 - {app_name} - Beta is OPEN! "
-                        f"(changed from {previous_status.value if previous_status else 'unknown'})"
-                    )
-                elif previous_status is None or previous_status != TestFlightStatus.OPEN:
-                    # Status transitioned into OPEN from another state
-                    should_notify = True
-                    logging.info(
-                        f"200 - {app_name} - Beta is OPEN! (status change from {previous_status.value if previous_status else 'unknown'})"
-                    )
-                else:
-                    logging.info(f"200 - {app_name} - Beta is still open (no notification)")
+                    if ALWAYS_NOTIFY_OPEN:
+                        should_notify = True
+                        logging.info(f"200 - {display_name} - Beta is OPEN (forced notification mode)")
+                    elif not already_notified:
+                        # First ever OPEN notification for this TestFlight ID
+                        should_notify = True
+                        logging.info(
+                            f"200 - {display_name} - Beta is OPEN! "
+                            f"(changed from {previous_status.value if previous_status else 'unknown'})"
+                        )
+                    elif previous_status is None or previous_status != TestFlightStatus.OPEN:
+                        # Status transitioned into OPEN from another state
+                        should_notify = True
+                        logging.info(
+                            f"200 - {display_name} - Beta is OPEN! (status change from {previous_status.value if previous_status else 'unknown'})"
+                        )
+                    else:
+                        logging.info(f"200 - {display_name} - Beta is still open (no notification)")
 
-                if should_notify:
-                    _open_notified[tf_id] = True
+                    if should_notify:
+                        _open_notified[tf_id] = True
 
         else:
             # Unknown status - log for investigation with more details
             raw_text = result.get("raw_text", "N/A")
             logging.warning(
-                f"200 - {app_name} - UNKNOWN status detected. "
+                f"200 - {display_name} - UNKNOWN status detected. "
                 f"Full raw text (first 200 chars): '{raw_text[:200]}' - "
                 f"Please check the TestFlight page and report this pattern "
                 f"so we can add it to STATUS_PATTERNS for proper detection."
@@ -491,7 +513,15 @@ async def fetch_testflight_status(session, tf_id):
 
         # Send notification if status changed to something noteworthy
         if should_notify:
-            notify_msg = await format_notification_link(TESTFLIGHT_URL, tf_id)
+            if current_status == TestFlightStatus.CLOSED:
+                notify_msg = (
+                    f"{display_name} beta is now closed: "
+                    f"{format_link(TESTFLIGHT_URL, tf_id)}"
+                )
+            else:
+                notify_msg = await format_notification_link(
+                    TESTFLIGHT_URL, tf_id, name_override=settings["friendly_name"]
+                )
             icon_url = await get_app_icon(TESTFLIGHT_URL, tf_id)
             # Use stock TestFlight icon if app icon is unavailable
             if not icon_url or icon_url == tf_id:
@@ -500,7 +530,7 @@ async def fetch_testflight_status(session, tf_id):
             await send_notification_async(notify_msg, apobj, icon_url)
             with _status_lock:
                 _last_notification_ts[tf_id] = time.time()
-            logging.info(f"Notification sent for {app_name}")
+            logging.info(f"Notification sent for {display_name}")
 
     except Exception as e:
         _record_failure(tf_id)
@@ -509,16 +539,34 @@ async def fetch_testflight_status(session, tf_id):
 
 
 async def watch():
-    """Check all TestFlight links that are not in retry cooldown."""
+    """Check enabled TestFlight links that are eligible this cycle.
+
+    Skips disabled apps, apps still in retry cooldown, and apps whose per-app
+    check-interval override has not yet elapsed. The rest are checked normally
+    so one broken or throttled ID can't delay or starve the others.
+    """
     try:
         current_ids = get_current_id_list()
         now = time.time()
-        # Skip only the IDs still in backoff; the rest are checked normally so
-        # one broken ID can't delay or starve the others.
-        eligible = [tf for tf in current_ids if not _is_in_cooldown(tf, now)]
+        eligible = []
+        for tf_id in current_ids:
+            settings = app_config.get(tf_id)
+            if not settings["enabled"]:
+                continue
+            if _is_in_cooldown(tf_id, now):
+                continue
+            interval = settings["check_interval_seconds"]
+            if interval and (now - _last_check_ts.get(tf_id, 0.0)) < interval:
+                continue
+            eligible.append(tf_id)
+
         skipped = len(current_ids) - len(eligible)
         if skipped:
-            logging.debug("Skipping %d TestFlight ID(s) in retry cooldown", skipped)
+            logging.debug("Skipping %d TestFlight ID(s) (disabled/cooldown/interval)", skipped)
+
+        for tf_id in eligible:
+            _last_check_ts[tf_id] = now
+
         session = await get_http_session()
         tasks = [fetch_testflight_status(session, tf_id) for tf_id in eligible]
         await asyncio.gather(*tasks, return_exceptions=True)
@@ -642,6 +690,9 @@ async def async_main():
         # Register signal handlers on the running loop so SIGTERM (e.g.
         # `docker stop`) triggers a graceful shutdown.
         install_signal_handlers()
+
+        # Load per-app configuration (enabled, friendly names, toggles, etc.).
+        app_config.load_from_disk()
 
         # Restore persisted runtime state before monitoring starts so we resume
         # without re-sending duplicate notifications, then (re)create the file.

--- a/routes.py
+++ b/routes.py
@@ -10,6 +10,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel, Field
 
+import app_config
 import config_io
 import state
 from state import (
@@ -185,6 +186,7 @@ async def get_testflight_ids_details():
     details = []
 
     for tf_id in current_ids:
+        settings = app_config.get(tf_id)
         try:
             # Get app name (with caching)
             app_name = await get_app_name(TESTFLIGHT_URL, tf_id)
@@ -192,22 +194,47 @@ async def get_testflight_ids_details():
             # Get app icon URL (with caching)
             icon_url = await get_app_icon(TESTFLIGHT_URL, tf_id)
 
+            # A friendly name overrides the detected name for display.
+            display_name = settings["friendly_name"] or app_name
             details.append(
                 {
                     "id": tf_id,
                     "app_name": app_name if app_name != tf_id else None,
-                    "display_name": app_name,
+                    "display_name": display_name,
                     "icon_url": icon_url,
+                    "settings": settings,
                 }
             )
         except Exception as e:
             logging.warning(f"Failed to get details for TestFlight ID {tf_id}: {e}")
-            # Fallback to just the ID
+            # Fallback to just the ID (still report its settings)
             details.append(
-                {"id": tf_id, "app_name": None, "display_name": tf_id, "icon_url": None}
+                {
+                    "id": tf_id,
+                    "app_name": None,
+                    "display_name": settings["friendly_name"] or tf_id,
+                    "icon_url": None,
+                    "settings": settings,
+                }
             )
 
     return {"testflight_ids": details}
+
+
+@router.post("/api/testflight-ids/{tf_id}/settings")
+async def update_app_settings(tf_id: str, request: Request):
+    """Update per-app settings for a monitored TestFlight ID (CSRF-protected)."""
+    if tf_id not in get_current_id_list():
+        raise HTTPException(status_code=404, detail="TestFlight ID not found")
+    try:
+        partial = await request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="Malformed JSON")
+    ok, message = app_config.update(tf_id, partial)
+    if not ok:
+        raise HTTPException(status_code=400, detail=message)
+    logging.info("Updated per-app settings for %s", tf_id)
+    return {"success": True, "settings": app_config.get(tf_id)}
 
 
 @router.post("/api/testflight-ids/validate")

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -257,22 +257,76 @@ function renderIds(ids) {
     return;
   }
   container.innerHTML = ids.map(item => {
+    const s = item.settings || {};
     const name = item.display_name || item.id;
     const hasSub = item.app_name && item.app_name !== item.id;
+    const disabled = s.enabled === false;
     const icon = item.icon_url
       ? `<img class="item-icon" src="${escAttr(item.icon_url)}" alt="" onerror="this.style.display='none'">`
       : `<div class="item-icon-placeholder">📱</div>`;
-    return `<div class="item-row">
+    const pid = `app-settings-${item.id}`;
+    const chk = (f, def) => ((s[f] !== undefined ? s[f] : def) ? 'checked' : '');
+    return `<div class="item-row"${disabled ? ' style="opacity:.55"' : ''}>
       ${icon}
       <div class="item-info">
-        <div class="item-name">${escHtml(name)}</div>
+        <div class="item-name">${escHtml(name)}${disabled ? ' <span class="text-muted text-sm">(disabled)</span>' : ''}</div>
         ${hasSub ? `<div class="item-sub">${escHtml(item.id)}</div>` : ''}
       </div>
       <div class="item-actions">
+        <button class="btn btn-sm btn-secondary" onclick="toggleAppSettings('${escAttr(item.id)}')">Settings</button>
         <button class="btn btn-sm btn-danger" onclick="removeId('${escAttr(item.id)}')" aria-label="Remove ${escAttr(name)}">Remove</button>
       </div>
+    </div>
+    <div id="${pid}" class="hidden" style="padding:10px 14px 14px; border-bottom:1px solid var(--border); display:grid; gap:8px;">
+      <label><input type="checkbox" data-f="enabled" ${chk('enabled', true)}> Enabled</label>
+      <label style="display:flex; gap:8px; align-items:center;">Friendly name
+        <input type="text" class="input" data-f="friendly_name" value="${escAttr(s.friendly_name || '')}" placeholder="(use detected name)" style="flex:1;"></label>
+      <label style="display:flex; gap:8px; align-items:center;">Check interval (s)
+        <input type="number" min="1" class="input" data-f="check_interval_seconds" value="${s.check_interval_seconds != null ? s.check_interval_seconds : ''}" placeholder="global" style="width:120px;"></label>
+      <label><input type="checkbox" data-f="notify_on_open" ${chk('notify_on_open', true)}> Notify on Open</label>
+      <label><input type="checkbox" data-f="notify_on_full" ${chk('notify_on_full', true)}> Notify on Full</label>
+      <label><input type="checkbox" data-f="notify_on_closed" ${chk('notify_on_closed', false)}> Notify on Closed</label>
+      <div class="btn-group">
+        <button class="btn btn-sm btn-primary" onclick="saveAppSettings('${escAttr(item.id)}')">Save</button>
+      </div>
+      <div class="status-msg" id="${pid}-status" role="status" aria-live="polite"></div>
     </div>`;
   }).join('');
+}
+
+function toggleAppSettings(id) {
+  const panel = document.getElementById(`app-settings-${id}`);
+  if (panel) panel.classList.toggle('hidden');
+}
+
+async function saveAppSettings(id) {
+  const panel     = document.getElementById(`app-settings-${id}`);
+  const statusDiv = document.getElementById(`app-settings-${id}-status`);
+  if (!panel) return;
+  const body = {};
+  panel.querySelectorAll('[data-f]').forEach(el => {
+    const f = el.dataset.f;
+    if (el.type === 'checkbox') {
+      body[f] = el.checked;
+    } else if (f === 'check_interval_seconds') {
+      body[f] = el.value.trim() === '' ? null : parseInt(el.value, 10);
+    } else {
+      body[f] = el.value.trim() === '' ? null : el.value.trim();
+    }
+  });
+  setStatus(statusDiv, 'Saving…', 'info');
+  try {
+    const res  = await fetch(`/api/testflight-ids/${encodeURIComponent(id)}/settings`, jsonPost(body));
+    const data = await res.json();
+    if (res.ok) {
+      showToast('App settings saved', 'success');
+      refreshIds();  // re-render to reflect disabled state / friendly name
+    } else {
+      setStatus(statusDiv, data.detail || 'Save failed.', 'error');
+    }
+  } catch (e) {
+    setStatus(statusDiv, `Error: ${e.message}`, 'error');
+  }
 }
 
 async function validateAndAddId() {

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -1,0 +1,258 @@
+"""Tests for per-app configuration (Runbook 2 — Task 10)."""
+
+import asyncio
+import os
+
+os.environ.setdefault("APPRISE_URL", "json://localhost/")
+os.environ.setdefault("ENABLE_UPDATE_CHECKER", "false")
+os.environ.pop("WEB_USERNAME", None)
+os.environ.pop("WEB_PASSWORD", None)
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app_config  # noqa: E402
+import config_io  # noqa: E402
+import main  # noqa: E402
+import routes  # noqa: E402
+import state  # noqa: E402
+from utils.testflight import TestFlightStatus  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _isolate_app_config(tmp_path, monkeypatch):
+    # Each test gets its own per-app config file and a clean in-memory store.
+    monkeypatch.setattr(app_config, "APP_CONFIG_FILE", str(tmp_path / "app_config.json"))
+    app_config._settings.clear()
+    yield
+    app_config._settings.clear()
+
+
+@pytest.fixture
+def client():
+    c = TestClient(main.app)
+    c.get("/")
+    token = c.cookies.get("csrf_token")
+    if token:
+        c.headers.update({"X-CSRF-Token": token})
+    return c
+
+
+def _clear_runtime():
+    for d in (main._previous_status, main._open_notified, main._last_check_ts):
+        d.clear()
+
+
+def _patch_fetch(monkeypatch, status, sent, names):
+    async def fake_check(session, url):
+        return {"status": status, "status_text": status.value, "app_name": "Detected"}
+
+    async def fake_name(b, t):
+        return "Detected"
+
+    async def fake_icon(b, t):
+        return "http://i/x.png"
+
+    async def fake_link(b, t, name_override=None):
+        names.append(name_override)
+        return "msg"
+
+    async def fake_send(*a, **k):
+        sent.append(a)
+
+    monkeypatch.setattr(main, "check_testflight_status", fake_check)
+    monkeypatch.setattr(main, "get_app_name", fake_name)
+    monkeypatch.setattr(main, "get_app_icon", fake_icon)
+    monkeypatch.setattr(main, "format_notification_link", fake_link)
+    monkeypatch.setattr(main, "send_notification_async", fake_send)
+    monkeypatch.setattr(main, "ALWAYS_NOTIFY_OPEN", False)
+
+
+# ── Backward compatibility / defaults ───────────────────────────
+def test_unconfigured_id_uses_defaults():
+    s = app_config.get("brandnew1")
+    assert s == app_config.DEFAULTS
+    assert s["enabled"] is True
+    assert s["notify_on_open"] is True and s["notify_on_full"] is True
+    assert s["notify_on_closed"] is False
+
+
+# ── Enabled / disabled ──────────────────────────────────────────
+def test_disabled_app_is_skipped(monkeypatch):
+    _clear_runtime()
+    app_config.update("disabled1", {"enabled": False})
+
+    checked = []
+
+    async def fake_fetch(session, tf_id):
+        checked.append(tf_id)
+
+    async def fake_session():
+        return object()
+
+    monkeypatch.setattr(main, "get_current_id_list", lambda: ["disabled1", "enabled01"])
+    monkeypatch.setattr(main, "get_http_session", fake_session)
+    monkeypatch.setattr(main, "fetch_testflight_status", fake_fetch)
+
+    asyncio.run(main.watch())
+    assert "enabled01" in checked  # other apps keep checking
+    assert "disabled1" not in checked  # disabled app is not checked
+
+
+# ── Friendly name ───────────────────────────────────────────────
+def test_friendly_name_overrides_in_details(client, monkeypatch):
+    async def fake_name(b, t):
+        return "Detected"
+
+    async def fake_icon(b, t):
+        return "ic"
+
+    monkeypatch.setattr(routes, "get_app_name", fake_name)
+    monkeypatch.setattr(routes, "get_app_icon", fake_icon)
+    saved = list(state.current_id_list)
+    try:
+        state.current_id_list[:] = ["friendly1"]
+        app_config.update("friendly1", {"friendly_name": "My Cool App"})
+        item = client.get("/api/testflight-ids/details").json()["testflight_ids"][0]
+        assert item["display_name"] == "My Cool App"
+        assert item["settings"]["friendly_name"] == "My Cool App"
+    finally:
+        state.current_id_list[:] = saved
+
+
+def test_friendly_name_used_in_notification(monkeypatch):
+    _clear_runtime()
+    app_config.update("friendly2", {"friendly_name": "Friendly!"})
+    sent, names = [], []
+    _patch_fetch(monkeypatch, TestFlightStatus.OPEN, sent, names)
+    asyncio.run(main.fetch_testflight_status(None, "friendly2"))
+    assert len(sent) == 1
+    assert names == ["Friendly!"]  # passed to the message builder
+
+
+def test_no_friendly_name_uses_detected(monkeypatch):
+    _clear_runtime()
+    sent, names = [], []
+    _patch_fetch(monkeypatch, TestFlightStatus.OPEN, sent, names)
+    asyncio.run(main.fetch_testflight_status(None, "plainid01"))
+    assert len(sent) == 1
+    assert names == [None]  # no override -> detected name used (default behavior)
+
+
+# ── Notification toggles ────────────────────────────────────────
+def test_default_open_notifies(monkeypatch):
+    _clear_runtime()
+    sent, names = [], []
+    _patch_fetch(monkeypatch, TestFlightStatus.OPEN, sent, names)
+    asyncio.run(main.fetch_testflight_status(None, "defopen01"))
+    assert len(sent) == 1  # default OPEN behavior preserved
+
+
+def test_open_notification_can_be_disabled(monkeypatch):
+    _clear_runtime()
+    app_config.update("noopen01", {"notify_on_open": False})
+    sent, names = [], []
+    _patch_fetch(monkeypatch, TestFlightStatus.OPEN, sent, names)
+    asyncio.run(main.fetch_testflight_status(None, "noopen01"))
+    assert sent == []  # OPEN notification suppressed
+
+
+def test_closed_off_by_default(monkeypatch):
+    _clear_runtime()
+    main._previous_status["closeflt1"] = TestFlightStatus.OPEN  # OPEN -> CLOSED transition
+    sent, names = [], []
+    _patch_fetch(monkeypatch, TestFlightStatus.CLOSED, sent, names)
+    asyncio.run(main.fetch_testflight_status(None, "closeflt1"))
+    assert sent == []  # closed notifications off by default (preserves behavior)
+
+
+def test_closed_notifies_when_enabled(monkeypatch):
+    _clear_runtime()
+    app_config.update("closeon01", {"notify_on_closed": True})
+    main._previous_status["closeon01"] = TestFlightStatus.OPEN
+    sent, names = [], []
+    _patch_fetch(monkeypatch, TestFlightStatus.CLOSED, sent, names)
+    asyncio.run(main.fetch_testflight_status(None, "closeon01"))
+    assert len(sent) == 1  # opt-in closed notification fires on transition
+
+
+# ── Import / export ─────────────────────────────────────────────
+def test_export_includes_app_settings(client):
+    app_config.update("exp00001", {"enabled": False, "friendly_name": "X"})
+    body = client.get("/api/config/export").json()
+    assert "app_settings" in body
+    assert body["app_settings"]["exp00001"]["enabled"] is False
+
+
+def test_import_accepts_app_settings(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".env").write_text("ID_LIST=x,\nAPPRISE_URL=discord://a/b,\n")
+    data = {
+        "version": 1,
+        "app_settings": {"impid001": {"enabled": False, "notify_on_full": False}},
+    }
+    normalized, error = config_io.validate_import(data)
+    assert error is None
+    assert config_io.apply_import(normalized) is True
+    assert app_config.get("impid001")["enabled"] is False
+    assert app_config.get("impid001")["notify_on_full"] is False
+
+
+def test_import_rejects_invalid_app_settings():
+    normalized, error = config_io.validate_import(
+        {"app_settings": {"bad1": {"enabled": "yes"}}}
+    )
+    assert normalized is None and "enabled" in error
+
+
+# ── Validation / endpoint ───────────────────────────────────────
+def test_invalid_settings_rejected():
+    ok, err = app_config.update("badid001", {"enabled": "yes"})
+    assert ok is False and "boolean" in err
+    ok, err = app_config.update("badid002", {"check_interval_seconds": 0})
+    assert ok is False
+    ok, err = app_config.update("badid003", {"unknown_key": 1})
+    assert ok is False and "Unknown" in err
+
+
+def test_settings_endpoint_valid(client):
+    saved = list(state.current_id_list)
+    try:
+        state.current_id_list[:] = ["okid0001"]
+        r = client.post(
+            "/api/testflight-ids/okid0001/settings",
+            json={"friendly_name": "Nice", "enabled": False},
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["settings"]["friendly_name"] == "Nice"
+        assert app_config.get("okid0001")["enabled"] is False
+    finally:
+        state.current_id_list[:] = saved
+
+
+def test_settings_endpoint_rejects_invalid(client):
+    saved = list(state.current_id_list)
+    try:
+        state.current_id_list[:] = ["epid0001"]
+        r = client.post("/api/testflight-ids/epid0001/settings", json={"enabled": "nope"})
+        assert r.status_code == 400
+    finally:
+        state.current_id_list[:] = saved
+
+
+def test_settings_endpoint_unknown_id(client):
+    assert client.post(
+        "/api/testflight-ids/nosuchid/settings", json={"enabled": True}
+    ).status_code == 404
+
+
+def test_settings_endpoint_requires_csrf():
+    c = TestClient(main.app)  # fresh client, no CSRF token
+    saved = list(state.current_id_list)
+    try:
+        state.current_id_list[:] = ["csrfid01"]
+        assert c.post(
+            "/api/testflight-ids/csrfid01/settings", json={"enabled": True}
+        ).status_code == 403
+    finally:
+        state.current_id_list[:] = saved

--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -66,7 +66,13 @@ def test_export_excludes_runtime_state(client):
         "icon_url",
     ):
         assert runtime_key not in blob
-    assert set(body) <= {"version", "testflight_ids", "settings", "notifications"}
+    assert set(body) <= {
+        "version",
+        "testflight_ids",
+        "settings",
+        "app_settings",
+        "notifications",
+    }
 
 
 # ── Import validation (no writes) ───────────────────────────────

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -108,7 +108,7 @@ def _patch_fetch_deps(monkeypatch, sent, status=TestFlightStatus.OPEN):
     async def fake_icon(base, tf):
         return "http://i/x.png"
 
-    async def fake_link(base, tf):
+    async def fake_link(base, tf, name_override=None):
         return "Beta is OPEN"
 
     async def fake_send(*a, **k):

--- a/utils/formatting.py
+++ b/utils/formatting.py
@@ -192,8 +192,10 @@ def format_link(base_url: str, tf_id: str) -> str:
     return f"{base_url.rstrip('/')}/{tf_id.lstrip('/')}"
 
 
-async def format_notification_link(base_url: str, tf_id: str) -> str:
-    app_name = await get_app_name(base_url, tf_id)
+async def format_notification_link(
+    base_url: str, tf_id: str, name_override: str = None
+) -> str:
+    app_name = name_override or await get_app_name(base_url, tf_id)
     return f"Slots available for {app_name}: {format_link(base_url, tf_id)}"
 
 


### PR DESCRIPTION
**Runbook 2 — Task 10.** Optional per-app settings for each monitored TestFlight ID.

## Per-app settings
`enabled` · `friendly_name` · `check_interval_seconds` · `notify_on_open` · `notify_on_full` · `notify_on_closed`. **Defaults preserve the original behavior** (enabled, no friendly name, global interval, OPEN/FULL on, CLOSED off).

## Behavior
- **Enabled/disabled** — disabled apps stay in config, are **not checked** (filtered in `watch()`), and render **dimmed** in the dashboard.
- **Friendly name** — overrides the detected name in the dashboard and notifications; falls back to the detected name when unset.
- **Check-interval override** — an app is skipped until its interval elapses (only ever *less* frequent than the global loop; no busy loop — the loop still sleeps and per-app skipping is per-cycle).
- **Notification toggles** — OPEN/FULL gated by their toggles (defaults on = current behavior); CLOSED is a new **opt-in** transition notification (default off, so behavior is unchanged).

## Storage (backward compatible)
`ID_LIST` in `.env` stays the source of monitored IDs, so **no existing IDs are lost**. Per-app overrides live in a separate `data/app_config.json` (`APP_CONFIG_FILE`), atomic + corruption-tolerant, **kept separate from the runtime state file**. Import/export include a non-secret `app_settings` map; secrets are never exposed.

## API
- `GET /api/testflight-ids/details` now returns `settings` + the friendly `display_name`.
- `POST /api/testflight-ids/{id}/settings` (new) updates per-app settings — **CSRF-protected**, validates input, 404 for unknown IDs.

## Dashboard
A minimal **Settings** panel under each app row (enable toggle, friendly name, interval, three notify toggles, Save). Not a redesign.

## Tests (`tests/test_app_config.py`, 17)
Defaults / simple list still works · disabled app skipped (others continue) · friendly name overrides (details + notification) · default OPEN notifies · OPEN can be disabled · CLOSED off by default · CLOSED notifies when enabled · export includes app_settings · import accepts app_settings · import rejects invalid · invalid settings rejected · settings endpoint valid/invalid/unknown-id/**CSRF**. Two pre-existing tests updated for the new `format_notification_link` signature and the `app_settings` export field. **Full suite: 90 passed**, pyflakes clean.

## Manual verification
Live: POST settings (CSRF) returned merged settings and wrote `data/app_config.json`; no-CSRF → 403; invalid → 400; `/details` showed the friendly `display_name` and `enabled:false`; export included `app_settings` with no secret. Browser-drove the per-app panel: Settings button + all six fields present, hidden by default, toggles open, and Save POSTs the correct body to `/api/testflight-ids/{id}/settings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)