### PR TITLE
Improve Docker startup validation

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -76,10 +76,37 @@ FASTAPI_PORT=8080
 
 ### Volumes
 
-The `docker-compose.yml` includes optional volume mounts:
+The `docker-compose.yml` mounts:
 
-- `./.env:/app/.env:ro` - Mount your .env file (read-only)
-- `./data:/app/data` - Persistent data directory (for future use)
+- `./.env:/app/.env` — your configuration file. Mounted **read-write** so the
+  dashboard config editor and add/remove of IDs/URLs can persist. The app reads
+  it at startup and still runs if it is read-only (those edit features are just
+  disabled, and a warning is logged).
+- `./data:/app/data` — **persistent runtime state and per-app config**. Mount
+  this to keep `data/state.json` (per-ID status, timestamps, failure counts,
+  caches) and `data/app_config.json` (per-app settings) across restarts.
+
+#### Permissions (non-root container)
+
+The image runs as a **non-root user (uid 10001)**. The host files/dirs it
+writes must be writable by that user, or writes silently fail (the app logs a
+clear startup warning and continues with those features disabled). On startup
+the app validates these paths and warns about any it can't write.
+
+If you hit permission warnings, give the container user ownership on the host:
+
+```bash
+# Make the mounted .env and data dir writable by the container user (uid 10001)
+sudo chown 10001:10001 .env
+mkdir -p data && sudo chown -R 10001:10001 data
+```
+
+> A present-but-**unreadable** `.env` is treated as a fatal misconfiguration and
+> the app refuses to start with a clear error. An unwritable (but readable)
+> `.env`, or an unwritable `data/`, only produces warnings.
+
+Logs go to the container's stdout (`docker compose logs`); the app does not
+write a log file, so no log path needs mounting.
 
 ### Networking
 
@@ -174,11 +201,14 @@ docker exec testflight-notifier curl http://localhost:8080/api/health
 
 ### Permission Issues
 
-If you encounter permission issues with volumes:
+The container runs as a non-root user (**uid 10001**). If the startup logs show
+`Startup path check: ... is not writable`, the mounted `.env` or `data/` isn't
+writable by that user. Fix the host ownership:
 
 ```bash
-# Linux: Fix permissions
-sudo chown -R $USER:$USER ./data
+# Make the mounted config + data writable by the container user (uid 10001)
+sudo chown 10001:10001 .env
+mkdir -p data && sudo chown -R 10001:10001 data
 ```
 
 ## Advanced Configuration

--- a/README.md
+++ b/README.md
@@ -90,7 +90,12 @@ The notifier detects the following TestFlight statuses:
    docker-compose logs -f
    ```
 
-For detailed Docker instructions, see [DOCKER.md](DOCKER.md).
+The container runs as a **non-root user (uid 10001)** and mounts `./.env`
+(read-write) and `./data` (persistent runtime state + per-app config). If those
+host paths aren't writable by uid 10001, the app logs a clear startup warning
+and continues with the affected features disabled — `sudo chown 10001:10001 .env`
+and `sudo chown -R 10001:10001 data` to fix. For detailed Docker instructions,
+including permissions, see [DOCKER.md](DOCKER.md).
 
 ## Configuration
 

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ import secrets
 import time
 import persistence
 import app_config
+import startup_checks
 from contextlib import asynccontextmanager
 from fastapi import FastAPI, HTTPException, Request, Depends
 from fastapi.responses import JSONResponse
@@ -669,6 +670,12 @@ async def start_fastapi():
 def main():
     """Main function to start all tasks."""
     validate_auth_config()
+    # Warn (or fail) about unwritable/unreadable runtime paths before serving.
+    if not startup_checks.run_startup_validation(
+        ".env", persistence.STATE_FILE, app_config.APP_CONFIG_FILE
+    ):
+        logging.error("Refusing to start: a required path is not readable.")
+        sys.exit(1)
     try:
         asyncio.run(async_main())
     except KeyboardInterrupt:

--- a/startup_checks.py
+++ b/startup_checks.py
@@ -1,0 +1,99 @@
+"""
+Startup validation of runtime paths.
+
+Before the app starts serving, checks that the paths it needs to read/write are
+accessible, so container users get clear warnings (and a clear failure for a
+truly required path) instead of silent feature breakage later. The checks are
+non-destructive: they only test access, never create or modify files, and they
+log paths only — never file contents — so no secrets are exposed.
+"""
+
+import logging
+import os
+
+
+def _readable(path: str) -> bool:
+    return os.access(path, os.R_OK)
+
+
+def _writable(path: str) -> bool:
+    return os.access(path, os.W_OK)
+
+
+def _dir_writable_or_creatable(path: str) -> bool:
+    """True if the file's directory exists and is writable, or can be created.
+
+    Walks up to the nearest existing ancestor and checks it is a writable
+    directory. Does not create anything.
+    """
+    directory = os.path.dirname(os.path.abspath(path)) or "."
+    d = directory
+    while not os.path.isdir(d):
+        parent = os.path.dirname(d)
+        if not parent or parent == d:
+            return False
+        d = parent
+    return _writable(d)
+
+
+def validate_runtime_paths(env_path: str, state_file: str, app_config_file: str):
+    """Return a list of ``(level, message)`` issues. ``level`` is 'error' or
+    'warning'. Pure: no logging, no filesystem modification."""
+    results = []
+
+    # .env — the configuration source. A present-but-unreadable config file is a
+    # truly broken setup (error); a read-only one only disables dashboard edits.
+    if os.path.exists(env_path):
+        if not _readable(env_path):
+            results.append(
+                ("error", f"Config file '{env_path}' exists but is not readable")
+            )
+        elif not _writable(env_path):
+            results.append(
+                (
+                    "warning",
+                    f"Config file '{env_path}' is not writable; dashboard config "
+                    f"edits and add/remove of IDs/URLs will not persist",
+                )
+            )
+
+    # Runtime state and per-app config files — optional (the app degrades
+    # gracefully), so only warn when they can't be written.
+    for path, what in ((state_file, "runtime state"), (app_config_file, "per-app config")):
+        if os.path.exists(path):
+            if not _writable(path):
+                results.append(
+                    (
+                        "warning",
+                        f"{what.capitalize()} file '{path}' is not writable; "
+                        f"{what} will not be saved",
+                    )
+                )
+        elif not _dir_writable_or_creatable(path):
+            directory = os.path.dirname(os.path.abspath(path)) or "."
+            results.append(
+                (
+                    "warning",
+                    f"Directory '{directory}' for {what} is not writable; {what} "
+                    f"will not be saved. If running as a non-root container, chown "
+                    f"it to the container user (uid 10001).",
+                )
+            )
+
+    return results
+
+
+def run_startup_validation(env_path: str, state_file: str, app_config_file: str) -> bool:
+    """Validate runtime paths, logging warnings/errors. Returns True if OK to
+    proceed (no error-level / truly-required failures)."""
+    results = validate_runtime_paths(env_path, state_file, app_config_file)
+    has_error = False
+    for level, message in results:
+        if level == "error":
+            logging.error("Startup path check: %s", message)
+            has_error = True
+        else:
+            logging.warning("Startup path check: %s", message)
+    if not results:
+        logging.info("Startup path checks passed (runtime paths are accessible)")
+    return not has_error

--- a/tests/test_startup_checks.py
+++ b/tests/test_startup_checks.py
@@ -1,0 +1,85 @@
+"""Tests for startup runtime-path validation (Runbook 3 — Task 11)."""
+
+import logging
+
+import startup_checks
+
+
+def _levels(results):
+    return [level for level, _ in results]
+
+
+def test_writable_env_and_creatable_paths_no_issues(tmp_path):
+    env = tmp_path / ".env"
+    env.write_text("APPRISE_URL=json://localhost/\n")
+    # state/app_config don't exist yet but the dir is writable -> creatable.
+    results = startup_checks.validate_runtime_paths(
+        str(env), str(tmp_path / "state.json"), str(tmp_path / "app_config.json")
+    )
+    assert results == []
+
+
+def test_non_writable_env_warns_but_does_not_fail(tmp_path, monkeypatch):
+    env = tmp_path / ".env"
+    env.write_text("APPRISE_URL=json://localhost/\n")
+    monkeypatch.setattr(
+        startup_checks, "_writable", lambda p: False if str(p) == str(env) else True
+    )
+    results = startup_checks.validate_runtime_paths(
+        str(env), str(tmp_path / "state.json"), str(tmp_path / "app_config.json")
+    )
+    assert any(level == "warning" and ".env" in msg for level, msg in results)
+    assert "error" not in _levels(results)  # not fatal
+
+
+def test_unreadable_env_is_fatal(tmp_path, monkeypatch):
+    env = tmp_path / ".env"
+    env.write_text("APPRISE_URL=json://localhost/\n")
+    monkeypatch.setattr(startup_checks, "_readable", lambda p: False)
+    results = startup_checks.validate_runtime_paths(
+        str(env), str(tmp_path / "state.json"), str(tmp_path / "app_config.json")
+    )
+    assert any(level == "error" and ".env" in msg for level, msg in results)
+    # run_startup_validation must report not-ok (caller fails startup).
+    assert startup_checks.run_startup_validation(
+        str(env), str(tmp_path / "state.json"), str(tmp_path / "app_config.json")
+    ) is False
+
+
+def test_missing_creatable_state_and_config_no_issues(tmp_path):
+    env = tmp_path / ".env"
+    env.write_text("APPRISE_URL=json://localhost/\n")
+    results = startup_checks.validate_runtime_paths(
+        str(env), str(tmp_path / "data" / "state.json"), str(tmp_path / "app_config.json")
+    )
+    # data/ doesn't exist but tmp_path is writable -> creatable.
+    assert results == []
+
+
+def test_non_writable_data_directory_warns(tmp_path, monkeypatch):
+    env = tmp_path / ".env"
+    env.write_text("APPRISE_URL=json://localhost/\n")
+    state = tmp_path / "data" / "state.json"  # data/ does not exist
+    appc = tmp_path / "data" / "app_config.json"
+    # Simulate a non-writable filesystem (e.g. unmounted/unowned data dir).
+    monkeypatch.setattr(startup_checks, "_writable", lambda p: False)
+    results = startup_checks.validate_runtime_paths(str(env), str(state), str(appc))
+    assert any("not writable" in msg for _, msg in results)
+    # state + per-app config dirs both warn; none are fatal.
+    assert "error" not in _levels(results)
+
+
+def test_validation_does_not_leak_secrets(tmp_path, monkeypatch, caplog):
+    env = tmp_path / ".env"
+    env.write_text(
+        "APPRISE_URL=discord://id/SUPERSECRETTOKEN123\nWEB_PASSWORD=hunter2pw\n"
+    )
+    # Force warnings so path messages are emitted, then confirm no secret leaks.
+    monkeypatch.setattr(startup_checks, "_writable", lambda p: False)
+    with caplog.at_level(logging.INFO):
+        startup_checks.run_startup_validation(
+            str(env), str(tmp_path / "state.json"), str(tmp_path / "app_config.json")
+        )
+    blob = " ".join(r.getMessage() for r in caplog.records)
+    assert "SUPERSECRETTOKEN123" not in blob
+    assert "hunter2pw" not in blob


### PR DESCRIPTION
**Runbook 3 — Task 11.** Validate runtime paths at startup so container users get clear warnings (and a clear failure for a truly required path) before the app serves requests.

## What is checked (`startup_checks.py`)
- **`.env`** — readable and writable.
- **Runtime state** file (`data/state.json`) — writable, or its directory writable/creatable.
- **Per-app config** file (`data/app_config.json`) — writable, or its directory writable/creatable.
- Logs: the app writes to **stdout**, not a file, so no log path is checked (noted in docs).

Checks use `os.access` only — **non-destructive** (never creates or modifies files) and log **paths, not contents**, so no secrets leak.

## Behavior
- **Truly required:** a present-but-**unreadable** `.env` → error, `main()` exits `1` with a clear message.
- **Optional (warn + continue):** unwritable `.env` (dashboard edits disabled), unwritable/uncreatable `data/` (state + per-app config won't persist). Each warning names the path and suggests `chown` to uid 10001.
- Runs in `main()` after the auth check, before `asyncio.run` → before uvicorn serves. Compatible with the existing `docker-compose.yml` (no behavior change for writable mounts).

## Docs (`DOCKER.md` + `README.md`)
Required mounts (`.env` read-write; `data/` for persistent runtime state + per-app config), the non-root container user (**uid 10001**), expected permissions, and example `chown` commands.

## Tests (`tests/test_startup_checks.py`, 6)
Writable `.env` + creatable paths → no issues · non-writable `.env` → warning (not fatal) · unreadable `.env` → fatal (`run_startup_validation` returns False) · missing-but-creatable state/config → no issues · non-writable data directory → warnings (both state + per-app config) · validation does not leak secrets (a `.env` with a token/password produces no secret in the logs). **Full suite: 96 passed**, pyflakes clean.

## Manual verification
Ran the app: writable paths logged `Startup path checks passed`; a read-only `data/` logged two clear warnings (`runtime state` and `per-app config`, with the `chown ... uid 10001` hint); the configured secret never appeared in the startup logs. (Note: `os.access` is bypassed for root, so writability checks are most meaningful for the non-root container user.)

## Constraints honored
No unrelated refactors; runtime-state and per-app-config formats unchanged; CI untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)