### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+name: CI
+
+on:
+  push:
+    branches: [main, pre-release]
+  pull_request:
+
+# The project targets Python 3.11 (matches the Docker base image python:3.11-slim).
+env:
+  PYTHON_VERSION: "3.11"
+
+jobs:
+  lint:
+    name: Lint / syntax
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - run: pip install pyflakes
+      - name: Syntax check (compileall)
+        run: python -m compileall -q .
+      - name: pyflakes
+        run: python -m pyflakes $(git ls-files '*.py')
+
+  test:
+    name: Python tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+      - name: Install dependencies
+        run: pip install -r requirements.txt -r tests/requirements-test.txt
+      - name: Run test suite
+        run: python -m pytest -q
+
+  docker:
+    name: Docker build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build image (no push)
+        run: docker build -t testflight-apprise-notifier:ci .
+
+  audit:
+    name: Dependency audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - run: pip install pip-audit
+      # Audits the pinned runtime dependencies for known vulnerabilities.
+      # Genuine findings should be fixed by tightening the version pins, not
+      # ignored. If upstream advisories cause unactionable noise, document the
+      # specific advisory here or add `continue-on-error: true` (deliberately,
+      # not blindly).
+      - name: pip-audit
+        run: pip-audit -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # TestFlight Apprise Notifier
 
+[![CI](https://github.com/klept0/TestFlight_Apprise_Notifier/actions/workflows/ci.yml/badge.svg)](https://github.com/klept0/TestFlight_Apprise_Notifier/actions/workflows/ci.yml)
+
 A Python-based monitoring tool that continuously checks Apple TestFlight beta availability and sends notifications through [Apprise](https://github.com/caronc/apprise) when slots become available.
 
 ## Features

--- a/tests/test_testflight.py
+++ b/tests/test_testflight.py
@@ -5,8 +5,7 @@ Run with: pytest tests/test_testflight.py -v
 """
 
 import pytest
-import asyncio
-from unittest.mock import Mock, patch, AsyncMock
+from unittest.mock import Mock, AsyncMock
 from utils.testflight import (
     TestFlightStatus,
     check_testflight_status,


### PR DESCRIPTION
**Runbook 3 — Task 12.** A simple GitHub Actions CI pipeline.

## Triggers
Pull requests, and pushes to `main` and `pre-release`.

## Jobs (`.github/workflows/ci.yml`)
1. **lint** — `python -m compileall` (syntax) + `pyflakes` on all tracked `.py`.
2. **test** — Python **3.11** (matches the `python:3.11-slim` base image), installs `requirements.txt` + `tests/requirements-test.txt`, runs the full `pytest` suite.
3. **docker** — `docker build` (no push); fails the workflow if the build fails.
4. **audit** — `pip-audit` of the pinned runtime dependencies (currently reports no known vulnerabilities). No advisories are suppressed; the workflow comment notes that genuine findings should be fixed by tightening pins.

Kept intentionally lightweight (pinned `actions/checkout@v4` / `setup-python@v5`, pip caching on the test job). The existing `bandit`, `dependency-review`, and `release` workflows are left untouched (they're scoped to `main`; this adds `pre-release` + PR coverage and the test/docker/audit jobs they don't provide).

## Also
- CI status **badge** added to the README.
- Removed two unused imports (`asyncio`, `unittest.mock.patch`) from `tests/test_testflight.py` so the new pyflakes job is green from day one — a test-only lint cleanup, no behavior change.

## Validation (local)
- **YAML** parses; triggers resolve to `push: [main, pre-release]` + `pull_request`; jobs = `lint, test, docker, audit`.
- **Lint** commands run clean locally: `compileall` OK, `pyflakes` clean across all tracked `.py`.
- **Tests**: `python -m pytest` (the exact CI command, no `PYTHONPATH` needed from repo root) → **96 passed**.
- **pip-audit** on `requirements.txt` → "No known vulnerabilities found".
- **Docker**: not runnable in this environment, but the `docker build -t … .` command is correct and the `Dockerfile` is valid (`FROM python:3.11-slim`, installs `requirements.txt`); the build runs in CI.

## Constraints honored
No application code or runtime behavior changed; no heavy tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)