### PR TITLE
Final pre-release cleanup

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    integration: tests that hit real external services (deselect with -m "not integration")

--- a/routes.py
+++ b/routes.py
@@ -595,22 +595,34 @@ async def save_config(content: str = Form(...)):
 
 @router.post("/api/config/restore")
 async def restore_config():
-    """Restore .env file from backup."""
+    """Restore .env from backup using a hardened atomic write."""
+    import tempfile
+
+    env_path = ".env"
+    backup_path = f"{env_path}.backup"
     try:
-        env_path = ".env"
-        backup_path = f"{env_path}.backup"
-        
         if not os.path.exists(backup_path):
             raise HTTPException(status_code=404, detail="No backup file found")
-        
+
         with open(backup_path, "r") as f:
             backup_content = f.read()
-        
-        with open(env_path, "w") as f:
-            f.write(backup_content)
-        
+
+        # Write to a temp file in the same directory, fsync, then atomically
+        # replace .env. No new backup is taken here: .env.backup is the source.
+        env_dir = os.path.dirname(os.path.abspath(env_path)) or "."
+        fd, tmp_path = tempfile.mkstemp(prefix=".env.", suffix=".tmp", dir=env_dir)
+        try:
+            with os.fdopen(fd, "w") as tmp:
+                tmp.write(backup_content)
+                tmp.flush()
+                os.fsync(tmp.fileno())
+            os.replace(tmp_path, env_path)
+        finally:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+
         logging.info("Configuration restored from backup via web interface")
-        
+
         return {
             "success": True,
             "message": "Configuration restored from backup. Restart the application for changes to take effect.",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -239,6 +239,37 @@ def test_save_config_aborts_on_null_byte(tmp_path, monkeypatch):
     assert env.read_text() == original
 
 
+# ── Hardened .env restore ───────────────────────────────────────
+def test_restore_config_atomic(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    env = tmp_path / ".env"
+    env.write_text("ID_LIST=current,\n")
+    restored = "ID_LIST=restored,\nAPPRISE_URL=discord://a/b,\n"
+    backup = tmp_path / ".env.backup"
+    backup.write_text(restored)
+
+    res = asyncio.run(routes.restore_config())
+    assert res["success"] is True
+    # .env now matches the backup exactly.
+    assert env.read_text() == restored
+    assert "restored" in res["content"]
+    # The backup (the source) is left untouched, and no temp files remain.
+    assert backup.read_text() == restored
+    assert not [p for p in tmp_path.iterdir() if p.name.endswith(".tmp")]
+
+
+def test_restore_config_no_backup_404(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    original = "ID_LIST=keep,\n"
+    (tmp_path / ".env").write_text(original)
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(routes.restore_config())
+    assert exc.value.status_code == 404
+    # .env untouched when there is no backup to restore.
+    assert (tmp_path / ".env").read_text() == original
+
+
 # ── CSRF protection ─────────────────────────────────────────────
 def test_csrf_blocks_state_change_without_token():
     # Fresh client with no CSRF cookie/header -> state change rejected.


### PR DESCRIPTION
Two small cleanups before beta.

## 1. Register the `integration` pytest marker
`tests/test_testflight.py` uses `@pytest.mark.integration`, which produced a `PytestUnknownMark` warning. Added a minimal `pytest.ini` registering the marker (with the standard `-m "not integration"` deselect hint). The warning is gone; test collection/behavior is otherwise unchanged.

## 2. Harden `/api/config/restore`
`restore_config` wrote `.env` with a plain `open(..., "w")`. It now uses the same hardened atomic write as `save_config` / `update_env_file` / the config importer: write to a temp file in the same directory, `flush` + `os.fsync`, then `os.replace`, cleaning up the temp file on any failure. **No new backup is taken during restore** — `.env.backup` is the source being restored, so backing up over it would be wrong. `GET /api/config` is unchanged.

## Tests
- `test_restore_config_atomic` — `.env` restored to exactly the backup content, the backup left untouched, and no temp files left behind.
- `test_restore_config_no_backup_404` — 404 and `.env` untouched when there's no backup.

## Validation
- Full suite **98 passed**; the `PytestUnknownMark` warning count is now **0**.
- `pyflakes` clean across all tracked `.py`; `compileall` OK.
- Live: saved a change (creating `.env.backup`), then restored — `.env` reverted exactly, with **0** leftover `.env.*.tmp` files.

## Constraints honored
No unrelated refactors; `GET /api/config` behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)