### PR TITLE
Add library archive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ data/.state.*.tmp
 .env.backup
 data/app_config.json
 data/.app_config.*.tmp
+data/library.json
+data/.json.*.tmp

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A Python-based monitoring tool that continuously checks Apple TestFlight beta av
 - 💾 **State Persistence** – Saves runtime state to disk and resumes after a restart without re-sending duplicate notifications
 - 📦 **Config Import/Export** – Export your monitored IDs and settings to a `config.json` and import them back (secrets excluded by default)
 - 🎛️ **Per-App Settings** – Enable/disable, friendly name, check-interval override, and per-status notification toggles for each monitored ID
+- 📚 **Library** – Apps removed from monitoring are archived (never checked, never notified); restore, delete, or clear them from a dedicated tab
 - 💓 **Heartbeat Notifications** – Optional periodic notifications to confirm the service is running
 - 🧪 **Test Notification** – Send a one-off test message to your configured destinations from the dashboard
 - 🎨 **Dark/Light Theme** – Responsive web dashboard with persistent theme preference
@@ -223,6 +224,7 @@ Once running, access the web dashboard at `http://localhost:8080` (or your confi
 - **Apprise URLs** – Add or remove notification endpoints on the fly, and send a test notification to confirm they work
 - **Settings** – Toggle options (update checker, always-notify), change the default theme, edit the `.env` file directly with the built-in editor, and import/export your configuration as `config.json`
 - **Logs** – Filterable live log viewer with level and line-count controls
+- **Library** – Archive of apps removed from monitoring, with search, sort, and restore/delete/clear actions
 
 ### API Endpoints
 
@@ -239,6 +241,9 @@ Interactive OpenAPI docs are available at `/docs`.
 | `/api/testflight-ids` | GET / POST | List or add a monitored TestFlight ID |
 | `/api/testflight-ids/details` | GET | Monitored IDs with app names, icons, and per-app settings |
 | `/api/testflight-ids/{id}/settings` | POST | Update per-app settings (enabled, friendly name, interval, notify toggles) |
+| `/api/library` | GET / DELETE | List archived apps (`?search=`, `?sort=name\|archived`) / clear all |
+| `/api/library/{id}/restore` | POST | Restore an archived app back to monitoring |
+| `/api/library/{id}` | DELETE | Delete a single archived app |
 | `/api/testflight-ids/{id}` | DELETE | Remove a TestFlight ID |
 | `/api/testflight-ids/batch` | POST | Add/remove multiple IDs at once |
 | `/api/apprise-urls` | GET / POST | List or add an Apprise notification URL |

--- a/library.py
+++ b/library.py
@@ -1,0 +1,134 @@
+"""
+Library: archive of apps that were removed from monitoring (History), plus a
+future-ready Favorites section (backend only).
+
+Persisted to ``data/library.json`` using the shared atomic JSON helpers in
+``persistence``. History entries are pure records — they are never monitored,
+never send notifications, and never participate in retry/backoff. The Library
+is kept entirely separate from runtime state (``data/state.json``).
+"""
+
+import os
+import threading
+import time
+
+import persistence
+
+LIBRARY_FILE = os.getenv("LIBRARY_FILE", "data/library.json")
+LIBRARY_VERSION = 1
+
+_lock = threading.Lock()
+_history = {}  # tf_id -> archive record
+_favorites = []  # future-ready; backend only
+
+
+def load_from_disk() -> None:
+    """Load the Library from disk. Tolerates a missing or corrupt file."""
+    global _history, _favorites
+    raw = persistence.read_json(LIBRARY_FILE, default={})
+    history = raw.get("history", {}) if isinstance(raw, dict) else {}
+    favorites = raw.get("favorites", []) if isinstance(raw, dict) else []
+    cleaned = {
+        tf_id: entry
+        for tf_id, entry in (history or {}).items()
+        if isinstance(entry, dict)
+    }
+    with _lock:
+        _history = cleaned
+        _favorites = favorites if isinstance(favorites, list) else []
+
+
+def _save() -> None:
+    with _lock:
+        snapshot = {
+            "version": LIBRARY_VERSION,
+            "history": {k: dict(v) for k, v in _history.items()},
+            "favorites": list(_favorites),
+        }
+    persistence.atomic_write_json(LIBRARY_FILE, snapshot)
+
+
+def archive(tf_id, app_name=None, icon_url=None, last_status=None) -> None:
+    """Archive an app removed from monitoring.
+
+    Never creates duplicates: if the ID is already in History, the existing
+    entry is updated (and ``last_archived`` refreshed) instead.
+    """
+    now = time.time()
+    with _lock:
+        existing = _history.get(tf_id)
+        if existing:
+            existing["last_archived"] = now
+            if app_name:
+                existing["app_name"] = app_name
+            if icon_url:
+                existing["icon_url"] = icon_url
+            if last_status is not None:
+                existing["last_status"] = last_status
+        else:
+            _history[tf_id] = {
+                "id": tf_id,
+                "app_name": app_name,
+                "icon_url": icon_url,
+                "last_status": last_status,
+                "first_archived": now,
+                "last_archived": now,
+            }
+    _save()
+
+
+def get_entry(tf_id):
+    """Return a copy of a History entry, or None."""
+    with _lock:
+        entry = _history.get(tf_id)
+        return dict(entry) if entry else None
+
+
+def get_history(search=None, sort="archived"):
+    """Return History entries, optionally filtered by ``search`` and sorted.
+
+    ``sort`` is 'name' (app name A→Z) or 'archived' (most recently archived
+    first, the default).
+    """
+    with _lock:
+        items = [dict(v) for v in _history.values()]
+
+    if search:
+        s = search.lower()
+        items = [
+            i
+            for i in items
+            if s in (i.get("app_name") or "").lower() or s in (i.get("id") or "").lower()
+        ]
+
+    if sort == "name":
+        items.sort(key=lambda i: (i.get("app_name") or i.get("id") or "").lower())
+    else:
+        items.sort(key=lambda i: i.get("last_archived") or 0, reverse=True)
+    return items
+
+
+def get_favorites():
+    """Return the Favorites list (future-ready; backend only)."""
+    with _lock:
+        return list(_favorites)
+
+
+def remove(tf_id) -> bool:
+    """Remove an entry from History. Returns True if it existed."""
+    with _lock:
+        present = tf_id in _history
+        if present:
+            del _history[tf_id]
+    if present:
+        _save()
+    return present
+
+
+def clear() -> int:
+    """Remove all History entries. Returns the number removed."""
+    with _lock:
+        count = len(_history)
+        _history.clear()
+    _save()
+    return count

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ import secrets
 import time
 import persistence
 import app_config
+import library
 import startup_checks
 from contextlib import asynccontextmanager
 from fastapi import FastAPI, HTTPException, Request, Depends
@@ -700,6 +701,8 @@ async def async_main():
 
         # Load per-app configuration (enabled, friendly names, toggles, etc.).
         app_config.load_from_disk()
+        # Load the Library (archive of removed apps).
+        library.load_from_disk()
 
         # Restore persisted runtime state before monitoring starts so we resume
         # without re-sending duplicate notifications, then (re)create the file.

--- a/persistence.py
+++ b/persistence.py
@@ -20,6 +20,48 @@ STATE_FILE = os.getenv("STATE_FILE", "data/state.json")
 STATE_VERSION = 1
 
 
+def read_json(path: str, default=None):
+    """Load a JSON value from ``path``; return ``default`` on missing/corrupt.
+
+    Generic, reusable counterpart to :func:`load_state` for other JSON stores
+    (e.g. the Library). Never raises on a bad or missing file.
+    """
+    fallback = {} if default is None else default
+    try:
+        if not os.path.exists(path):
+            return fallback
+        with open(path, "r") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, ValueError, OSError) as e:
+        logging.warning("Could not read JSON file '%s' (%s); using default", path, e)
+        return fallback
+
+
+def atomic_write_json(path: str, data) -> bool:
+    """Atomically write ``data`` as JSON to ``path`` (temp + fsync + os.replace).
+
+    Generic, reusable counterpart to :func:`save_state`. Returns True on
+    success; logs and returns False on failure (never raises).
+    """
+    try:
+        directory = os.path.dirname(os.path.abspath(path)) or "."
+        os.makedirs(directory, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(prefix=".json.", suffix=".tmp", dir=directory)
+        try:
+            with os.fdopen(fd, "w") as tmp:
+                json.dump(data, tmp, indent=2)
+                tmp.flush()
+                os.fsync(tmp.fileno())
+            os.replace(tmp_path, path)
+        finally:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+        return True
+    except OSError as e:
+        logging.error("Failed to write JSON file '%s': %s", path, e)
+        return False
+
+
 def load_state() -> dict:
     """Load persisted runtime state.
 

--- a/routes.py
+++ b/routes.py
@@ -12,6 +12,8 @@ from pydantic import BaseModel, Field
 
 import app_config
 import config_io
+import library
+import persistence
 import state
 from state import (
     apobj,
@@ -288,13 +290,26 @@ async def add_id(payload: TestFlightIdRequest):
     return {"message": message, "testflight_ids": get_current_id_list()}
 
 
+def _archive_to_library(tf_id):
+    """Archive a removed app into the Library History (best-effort metadata)."""
+    settings = app_config.get(tf_id)
+    cache_key = f"{TESTFLIGHT_URL}:{tf_id}"
+    app_name = settings.get("friendly_name") or app_name_cache.get(cache_key)
+    icon_url = app_icon_cache.get(cache_key)
+    state_data = persistence.read_json(persistence.STATE_FILE, default={})
+    apps = state_data.get("apps", {}) if isinstance(state_data, dict) else {}
+    last_status = (apps.get(tf_id) or {}).get("status")
+    library.archive(tf_id, app_name=app_name, icon_url=icon_url, last_status=last_status)
+
+
 @router.delete("/api/testflight-ids/{tf_id}")
 async def remove_id(tf_id: str):
-    """Remove a TestFlight ID."""
+    """Remove a TestFlight ID (and archive it to the Library)."""
     success, message = remove_testflight_id(tf_id)
     if not success:
         raise HTTPException(status_code=404, detail=message)
 
+    _archive_to_library(tf_id)
     return {"message": message, "testflight_ids": get_current_id_list()}
 
 
@@ -361,6 +376,7 @@ async def batch_operations(payload: BatchIdRequest):
         try:
             success, message = remove_testflight_id(tf_id)
             if success:
+                _archive_to_library(tf_id)
                 result["removed"]["successful"].append(tf_id)
             else:
                 result["removed"]["failed"].append({"id": tf_id, "error": message})
@@ -675,6 +691,46 @@ async def import_config(request: Request):
         "success": True,
         "message": "Configuration imported. Restart to apply changes.",
     }
+
+
+# ── Library (archive of removed apps) ──────────────────────────────────────
+@router.get("/api/library")
+async def get_library(search: str = None, sort: str = "archived"):
+    """List archived (History) apps. Optional ?search= and ?sort=name|archived."""
+    return {
+        "history": library.get_history(search=search, sort=sort),
+        "favorites": library.get_favorites(),
+    }
+
+
+@router.post("/api/library/{tf_id}/restore")
+async def restore_from_library(tf_id: str):
+    """Restore an archived app back to monitoring (CSRF-protected)."""
+    if not library.get_entry(tf_id):
+        raise HTTPException(status_code=404, detail="Not in library")
+    if tf_id not in get_current_id_list():
+        success, message = add_testflight_id(tf_id)
+        if not success:
+            raise HTTPException(status_code=400, detail=message)
+    library.remove(tf_id)
+    logging.info("Restored %s from library to monitoring", tf_id)
+    return {"success": True, "testflight_ids": get_current_id_list()}
+
+
+@router.delete("/api/library/{tf_id}")
+async def delete_from_library(tf_id: str):
+    """Delete a single History entry (CSRF-protected)."""
+    if not library.remove(tf_id):
+        raise HTTPException(status_code=404, detail="Not in library")
+    return {"success": True}
+
+
+@router.delete("/api/library")
+async def clear_library():
+    """Clear all History entries (CSRF-protected)."""
+    count = library.clear()
+    logging.info("Cleared %d entries from library", count)
+    return {"success": True, "removed": count}
 
 
 @router.get("/config")

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -62,6 +62,7 @@ const SECTION_TITLES = {
   urls:      'Apprise URLs',
   settings:  'Settings',
   logs:      'Logs',
+  library:   'Library',
 };
 
 function navigateTo(sectionId) {
@@ -99,6 +100,7 @@ function onSectionActivated(sectionId) {
   if (sectionId === 'urls')      refreshUrls();
   if (sectionId === 'settings')  loadConfig();
   if (sectionId === 'logs')      refreshLogs();
+  if (sectionId === 'library')   refreshLibrary();
 }
 
 // Wire up nav buttons
@@ -606,6 +608,109 @@ async function importConfig(input) {
     setStatus(statusDiv, `Error: ${e.message}`, 'error');
   } finally {
     input.value = '';
+  }
+}
+
+/* ── Library (archive) ──────────────────────────────────────── */
+let _libraryData = [];
+
+async function refreshLibrary() {
+  const container = document.getElementById('library-list');
+  try {
+    const res  = await fetch('/api/library');
+    const data = await res.json();
+    _libraryData = data.history || [];
+    renderLibrary();
+  } catch (e) {
+    container.innerHTML = errorRow('Failed to load library.');
+  }
+}
+
+function renderLibrary() {
+  const container = document.getElementById('library-list');
+  const search = (document.getElementById('library-search').value || '').toLowerCase();
+  const sort   = document.getElementById('library-sort').value;
+  let items = _libraryData.slice();
+  if (search) {
+    items = items.filter(i =>
+      (i.app_name || '').toLowerCase().includes(search) ||
+      (i.id || '').toLowerCase().includes(search));
+  }
+  if (sort === 'name') {
+    items.sort((a, b) => (a.app_name || a.id || '').toLowerCase()
+      .localeCompare((b.app_name || b.id || '').toLowerCase()));
+  } else {
+    items.sort((a, b) => (b.last_archived || 0) - (a.last_archived || 0));
+  }
+  if (!items.length) {
+    container.innerHTML = emptyState('📚', search ? 'No matching archived apps' : 'No archived apps yet');
+    return;
+  }
+  container.innerHTML = items.map(item => {
+    const name   = item.app_name || item.id;
+    const icon   = item.icon_url
+      ? `<img class="item-icon" src="${escAttr(item.icon_url)}" alt="" onerror="this.style.display='none'">`
+      : `<div class="item-icon-placeholder">📱</div>`;
+    const status = item.last_status ? escHtml(item.last_status) : '—';
+    const when   = item.last_archived ? new Date(item.last_archived * 1000).toLocaleString() : '';
+    return `<div class="item-row">
+      ${icon}
+      <div class="item-info">
+        <div class="item-name">${escHtml(name)}</div>
+        <div class="item-sub">${escHtml(item.id)} · status: ${status} · archived ${escHtml(when)}</div>
+      </div>
+      <div class="item-actions">
+        <button class="btn btn-sm btn-secondary" onclick="restoreFromLibrary('${escAttr(item.id)}')">Restore</button>
+        <button class="btn btn-sm btn-danger" onclick="deleteFromLibrary('${escAttr(item.id)}')">Delete</button>
+      </div>
+    </div>`;
+  }).join('');
+}
+
+async function restoreFromLibrary(id) {
+  try {
+    const res  = await fetch(`/api/library/${encodeURIComponent(id)}/restore`, { method: 'POST' });
+    const data = await res.json();
+    if (res.ok) {
+      showToast('Restored to monitoring', 'success');
+      refreshLibrary();
+      if (typeof refreshIds === 'function') refreshIds();
+    } else {
+      showToast(data.detail || 'Restore failed.', 'error');
+    }
+  } catch (e) {
+    showToast(`Error: ${e.message}`, 'error');
+  }
+}
+
+async function deleteFromLibrary(id) {
+  try {
+    const res = await fetch(`/api/library/${encodeURIComponent(id)}`, { method: 'DELETE' });
+    if (res.ok) {
+      showToast('Removed from library', 'success');
+      refreshLibrary();
+    } else {
+      const data = await res.json();
+      showToast(data.detail || 'Delete failed.', 'error');
+    }
+  } catch (e) {
+    showToast(`Error: ${e.message}`, 'error');
+  }
+}
+
+async function clearLibrary() {
+  if (!window.confirm('Delete all archived apps from the library? This cannot be undone.')) return;
+  try {
+    const res  = await fetch('/api/library', { method: 'DELETE' });
+    const data = await res.json();
+    if (res.ok) {
+      showToast(`Cleared ${data.removed} archived app(s)`, 'success');
+      refreshLibrary();
+    } else {
+      showToast(data.detail || 'Clear failed.', 'error');
+    }
+  } catch (e) {
+    showToast(`Error: ${e.message}`, 'error');
   }
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -70,6 +70,14 @@
           <span class="nav-text">Logs</span>
         </button>
       </li>
+      <li>
+        <button class="nav-item" data-section="library">
+          <svg class="nav-icon" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+            <path d="M2 5a2 2 0 012-2h3.28a1 1 0 01.948.684l.32.948a1 1 0 00.948.684H16a2 2 0 012 2v6a2 2 0 01-2 2H4a2 2 0 01-2-2V5z"/>
+          </svg>
+          <span class="nav-text">Library</span>
+        </button>
+      </li>
     </ul>
 
     <div class="sidebar-footer">
@@ -445,6 +453,40 @@
           <div id="logs-container" class="logs-container" aria-live="polite" aria-label="Application logs">
             <div class="empty-state">
               <div class="empty-state-text">Loading logs…</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ═══════════════════════════════════
+           Library Section
+           ═══════════════════════════════════ -->
+      <section id="section-library" class="section" aria-labelledby="title-library">
+        <div class="section-header">
+          <h2 id="title-library">Library</h2>
+          <p class="text-muted">Apps you have removed from monitoring are archived here. They are never checked and never send notifications.</p>
+        </div>
+
+        <div class="card">
+          <div class="card-header">
+            <h3>History</h3>
+            <div class="log-controls">
+              <input type="search" id="library-search" class="input" style="width:auto;" placeholder="Search…" oninput="renderLibrary()">
+              <label for="library-sort" class="sr-only">Sort by</label>
+              <select id="library-sort" class="input" style="width:auto;" onchange="renderLibrary()">
+                <option value="archived" selected>Recently archived</option>
+                <option value="name">App name</option>
+              </select>
+              <button class="btn btn-sm btn-danger" onclick="clearLibrary()">Clear All</button>
+              <button class="btn-icon" onclick="refreshLibrary()" aria-label="Refresh library" title="Refresh">
+                <svg viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z" clip-rule="evenodd"/></svg>
+              </button>
+            </div>
+          </div>
+          <div id="library-list" class="item-list">
+            <div class="empty-state">
+              <div class="empty-state-icon">📚</div>
+              <div class="empty-state-text">Loading…</div>
             </div>
           </div>
         </div>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,27 @@
+"""Shared test fixtures.
+
+Isolates the on-disk JSON stores (runtime state, library, per-app config) to a
+per-test temp directory so the suite never touches the repo's ``data/``
+directory, and starts each test from a clean in-memory state.
+"""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_data_files(tmp_path, monkeypatch):
+    import persistence
+    import library
+    import app_config
+
+    monkeypatch.setattr(persistence, "STATE_FILE", str(tmp_path / "state.json"))
+    monkeypatch.setattr(library, "LIBRARY_FILE", str(tmp_path / "library.json"))
+    monkeypatch.setattr(app_config, "APP_CONFIG_FILE", str(tmp_path / "app_config.json"))
+
+    library._history.clear()
+    library._favorites.clear()
+    app_config._settings.clear()
+    yield
+    library._history.clear()
+    library._favorites.clear()
+    app_config._settings.clear()

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -1,0 +1,156 @@
+"""Tests for the Library archive feature."""
+
+import os
+import time
+
+os.environ.setdefault("APPRISE_URL", "json://localhost/")
+os.environ.setdefault("ENABLE_UPDATE_CHECKER", "false")
+os.environ.pop("WEB_USERNAME", None)
+os.environ.pop("WEB_PASSWORD", None)
+
+import pytest
+from fastapi.testclient import TestClient
+
+import library  # noqa: E402
+import main  # noqa: E402
+import routes  # noqa: E402
+import state  # noqa: E402
+
+
+@pytest.fixture
+def client():
+    c = TestClient(main.app)
+    c.get("/")
+    token = c.cookies.get("csrf_token")
+    if token:
+        c.headers.update({"X-CSRF-Token": token})
+    return c
+
+
+# ── Library module ──────────────────────────────────────────────
+def test_archive_creates_entry():
+    library.archive("abc12345", app_name="Cool App", icon_url="http://i/x.png", last_status="open")
+    e = library.get_entry("abc12345")
+    assert e["id"] == "abc12345"
+    assert e["app_name"] == "Cool App"
+    assert e["icon_url"] == "http://i/x.png"
+    assert e["last_status"] == "open"
+    assert e["first_archived"] == e["last_archived"]
+
+
+def test_archive_never_duplicates_and_updates():
+    library.archive("dup12345", app_name="First", last_status="open")
+    first = library.get_entry("dup12345")["first_archived"]
+    time.sleep(0.01)
+    library.archive("dup12345", app_name="Second", last_status="full")
+    assert len(library.get_history()) == 1  # no duplicate
+    e = library.get_entry("dup12345")
+    assert e["app_name"] == "Second"  # updated
+    assert e["last_status"] == "full"
+    assert e["first_archived"] == first  # first_archived preserved
+    assert e["last_archived"] >= first  # last_archived refreshed
+
+
+def test_remove_and_clear():
+    library.archive("rm111111")
+    library.archive("rm222222")
+    assert library.remove("rm111111") is True
+    assert library.remove("rm111111") is False  # already gone
+    assert library.get_entry("rm111111") is None
+    assert library.clear() == 1  # one left
+    assert library.get_history() == []
+
+
+def test_search_and_sort():
+    library.archive("zeb11111", app_name="Zebra")
+    time.sleep(0.01)
+    library.archive("app22222", app_name="Apple")
+    assert [i["app_name"] for i in library.get_history(sort="name")] == ["Apple", "Zebra"]
+    # Most recently archived first.
+    assert library.get_history(sort="archived")[0]["id"] == "app22222"
+    res = library.get_history(search="zeb")
+    assert len(res) == 1 and res[0]["id"] == "zeb11111"
+
+
+def test_persistence_survives_restart():
+    library.archive("persist1", app_name="P", last_status="full")
+    # Simulate a restart: drop in-memory state and reload from the file.
+    library._history.clear()
+    library._favorites.clear()
+    library.load_from_disk()
+    e = library.get_entry("persist1")
+    assert e and e["app_name"] == "P" and e["last_status"] == "full"
+
+
+# ── API: archive-on-remove + endpoints ──────────────────────────
+def _allow_removal(monkeypatch):
+    monkeypatch.setattr(state, "update_env_file", lambda *a, **k: True)
+    monkeypatch.setattr(state, "send_notification", lambda *a, **k: None)
+
+
+def test_remove_archives_to_library(client, monkeypatch):
+    _allow_removal(monkeypatch)
+    tf = "arch1234"
+    state.current_id_list[:] = [tf]
+    routes.app_name_cache.put(f"{routes.TESTFLIGHT_URL}:{tf}", "Cached Name")
+    try:
+        r = client.delete(f"/api/testflight-ids/{tf}")
+        assert r.status_code == 200, r.text
+        entry = library.get_entry(tf)
+        assert entry is not None
+        assert entry["app_name"] == "Cached Name"
+    finally:
+        state.current_id_list[:] = []
+
+
+def test_get_library_endpoint(client):
+    library.archive("getlib01", app_name="Lib App")
+    body = client.get("/api/library").json()
+    assert "history" in body and "favorites" in body
+    assert any(i["id"] == "getlib01" for i in body["history"])
+
+
+def test_restore_endpoint(client, monkeypatch):
+    _allow_removal(monkeypatch)
+    monkeypatch.setattr(state, "validate_apprise_url", lambda u: (True, "ok"))
+    tf = "restore1"
+    library.archive(tf, app_name="R")
+    state.current_id_list[:] = []
+    try:
+        r = client.post(f"/api/library/{tf}/restore")
+        assert r.status_code == 200, r.text
+        assert tf in state.current_id_list  # back in monitoring
+        assert library.get_entry(tf) is None  # removed from library
+    finally:
+        state.current_id_list[:] = []
+
+
+def test_restore_unknown_404(client):
+    assert client.post("/api/library/nosuch1/restore").status_code == 404
+
+
+def test_delete_endpoint(client):
+    library.archive("del11111")
+    assert client.request("DELETE", "/api/library/del11111").status_code == 200
+    assert library.get_entry("del11111") is None
+    assert client.request("DELETE", "/api/library/del11111").status_code == 404
+
+
+def test_clear_all_endpoint(client):
+    library.archive("clr11111")
+    library.archive("clr22222")
+    r = client.request("DELETE", "/api/library")
+    assert r.status_code == 200
+    assert r.json()["removed"] == 2
+    assert library.get_history() == []
+
+
+# ── CSRF on state-changing library endpoints ────────────────────
+def test_library_endpoints_require_csrf():
+    c = TestClient(main.app)  # no CSRF token
+    library.archive("csrf1234")
+    assert c.post("/api/library/csrf1234/restore").status_code == 403
+    assert c.request("DELETE", "/api/library/csrf1234").status_code == 403
+    assert c.request("DELETE", "/api/library").status_code == 403
+    # A safe GET is unaffected.
+    assert c.get("/api/library").status_code == 200


### PR DESCRIPTION
Adds a **Library** that archives apps removed from monitoring, with future-ready backend support for Favorites.

## Storage
New `data/library.json`, written via the **shared atomic JSON helpers** (`persistence.read_json` / `persistence.atomic_write_json` — added as generic reuses of the existing temp+fsync+`os.replace` pattern). Kept entirely separate from runtime state (`data/state.json`) and the simple `.env` ID list — fully backward compatible (a missing file just means an empty Library).

## History
When an app is removed from monitoring (single delete **and** batch), it's archived automatically:
- **Never duplicates** — an existing entry is updated and its `last_archived` refreshed.
- Stores `id`, `app_name`, `icon_url` (if available), `last_status`, `first_archived`, `last_archived`.
- History entries are **never monitored, never notify, never retried** (they're inert records, not part of `current_id_list`).

## Favorites
Backend only (a `favorites` list in the file + returned by `GET /api/library`); no UI, per "backend support only if UI isn't needed."

## API (CSRF-protected where state-changing)
- `GET /api/library` — `?search=` + `?sort=name|archived`.
- `POST /api/library/{id}/restore` — re-add to monitoring, drop from History.
- `DELETE /api/library/{id}` — delete one entry.
- `DELETE /api/library` — clear all.

## Dashboard
A **Library** tab: icon, app name, ID, last status, archived date; a search box; sort by App Name / Archived Date; Restore / Delete / Clear All actions. Functional, not a redesign.

## Tests (`tests/test_library.py`, 12)
Archive creates entry · no duplicates (updates + refreshes `last_archived`) · remove + clear · search + sort · persistence + restart (`load_from_disk`) · archive-on-remove via the API · `GET /api/library` · restore (back to monitoring, removed from library) · restore-unknown 404 · delete (+ 404) · clear-all · **CSRF** on restore/delete/clear (GET unaffected). Added `tests/conftest.py` to isolate the JSON stores per test. **Full suite: 110 passed**, pyflakes clean.

## Manual verification
Seeded `data/library.json`, opened the dashboard: the **Library** tab renders the entry (name, ID, status, archived date), search filters it out/in, and the action buttons fire the right calls — `POST /api/library/{id}/restore` (then refreshes IDs + library), `DELETE /api/library/{id}`, and Clear All → `DELETE /api/library`.

## Constraints honored
Reused persistence helpers; runtime state kept separate; no unrelated refactors; backward compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)