### PR TITLE
Fix pytest collection warnings

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,22 @@ per-test temp directory so the suite never touches the repo's ``data/``
 directory, and starts each test from a clean in-memory state.
 """
 
+import enum
+
 import pytest
+
+
+def pytest_pycollect_makeitem(collector, name, obj):
+    """Skip collecting imported Enum classes as test classes.
+
+    ``utils.testflight.TestFlightStatus`` is an Enum imported into several test
+    modules; its name matches pytest's default ``Test*`` class pattern, which
+    triggers a ``PytestCollectionWarning``. Enums are never test classes, so
+    tell pytest to collect nothing for them.
+    """
+    if isinstance(obj, type) and issubclass(obj, enum.Enum):
+        return []
+    return None
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Cosmetic test-only cleanup.

## Problem
`utils.testflight.TestFlightStatus` is an `Enum` imported into several test modules. Its name matches pytest's default `Test*` class pattern, so pytest tried to collect it as a test class and emitted:

```
PytestCollectionWarning: cannot collect test class 'TestFlightStatus' because it has a __init__ constructor
```

## Fix
A `pytest_pycollect_makeitem` hook in `tests/conftest.py` that returns `[]` (collect nothing) for `Enum` subclasses, so imported enums are never treated as test classes. The real `Test*` **test classes** in `tests/test_testflight.py` (e.g. `TestRateLimiter`, `TestCaching`) are not enums, so they're collected exactly as before.

## Constraints honored
- **Test-only change** — `tests/conftest.py` is the single modified file; no application code is touched.
- No runtime behavior change.
- Test count unchanged (**110 passed**), confirming no real tests were skipped.

## Validation
- `PytestCollectionWarning` count: **0** (was several). The only remaining warning is an unrelated, pre-existing external `StarletteDeprecationWarning` from `fastapi`/`httpx`, out of scope here.
- Full suite: **110 passed**.
- `pyflakes` clean across all tracked `.py`; `compileall` OK.
- CI runs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)